### PR TITLE
fix: Cookware changed `ingredient` -> `cookware`

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -294,7 +294,7 @@ export class CookView extends TextFileView {
           ispan.appendText(s.name)
         }
         else if (s instanceof Cookware) {
-          mp.createSpan({ cls: 'ingredient', text: s.name });
+          mp.createSpan({ cls: 'cookware', text: s.name });
         }
         else if (s instanceof Timer) {
           const containerSpan = mp.createSpan()


### PR DESCRIPTION
Fixes  #26

I noticed that this was just a typo, and went ahead with this fix.  [Style for span.cookware is already equivalent to span.ingredient in the default styling](https://github.com/deathau/cooklang-obsidian/blob/main/src/styles.scss#L54-L55), though I don't know how custom user-styles might be affected.