### PR TITLE
feat: add toggle preview keyboard shortcut

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -211,7 +211,7 @@ export class CookView extends TextFileView {
         });
     }
 
-    switchMode(arg: 'source' | 'preview' | MouseEvent) {
+    switchMode(arg?: 'source' | 'preview' | MouseEvent) {
         let mode = arg;
         // if force mode not provided, switch to opposite of current mode
         if (!mode || mode instanceof MouseEvent) mode = this.currentView === 'source' ? 'preview' : 'source';

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ export default class CookPlugin extends Plugin {
     // - Create new recipe
     // - Create recipe in new pane
     // - Convert markdown file to `.cook`
+    // - Toggle preview recipe
 
     this.addCommand({
       id: "create-cook",
@@ -70,6 +71,19 @@ export default class CookPlugin extends Plugin {
         }
       }
     })
+
+    this.addCommand({
+      id: "toggle-preview-recipe",
+      name: "Toggle preview recipe",
+      callback: () => {
+        const { workspace } = this.app;
+
+        const activeLeaf = workspace.activeLeaf || workspace.getLeaf();
+        if (activeLeaf && activeLeaf.view instanceof CookView) {
+          activeLeaf.view.switchMode();
+        }
+      },
+    });
   }
 
   cookFileCreator = async () => {


### PR DESCRIPTION
Adding a new `Toggle preview recipe` hotkey for switching between preview and edit mode, for a workflow similar to `.md` files.

I could change the use of the deprecated `workspace.activeLeaf` to a slightly more "tedious" logic of getting by id if needed.

<img width="769" height="179" alt="image" src="https://github.com/user-attachments/assets/10890627-f3a7-4d95-be93-83df719c0040" />


https://github.com/user-attachments/assets/e1f6f097-0e09-4fa8-9f4c-2e1f845e8e5c

