### PR TITLE
Update new recipe file creation context menu option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -61,17 +61,20 @@ export default class CookPlugin extends Plugin {
     // Register file explorer context menu
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu: Menu, file: TFile | TFolder) => {
-        // Add "Create Recipe" option for folders and files
-        menu.addItem((item) => {
-          item
-            .setTitle('Create Recipe')
-            .setIcon('document-cook')
-            .onClick(async () => {
-              const folderPath = file instanceof TFolder ? file.path : file.parent?.path || '/';
-              const newFile = await this.cookFileCreator(folderPath);
-              this.app.workspace.getLeaf().openFile(newFile);
-            });
-        });
+        if (file instanceof TFolder) {
+          // Add "New recipe" option for folders
+          menu.addItem((item) => {
+            item
+              .setTitle('New recipe')
+              .setIcon('document-cook')
+              .setSection('action-primary')
+              .onClick(async () => {
+                const folderPath = file.path;
+                const newFile = await this.cookFileCreator(folderPath);
+                this.app.workspace.getLeaf().openFile(newFile);
+              });
+          });
+        }
 
         // Add "Open as Recipe" option for .md files
         if (file instanceof TFile && file.extension === 'md') {


### PR DESCRIPTION
This PR is about changing the right-click context menu item for creating a new recipe file. Currently named "Create Recipe" it shows up in a way that is unfamiliar to a user which can make its purpose unclear (personal anecdote). There are three things that I believe should be changed to have this context menu item appear and behave like a user is familiar with.

1. **The action is renamed from "Create Recipe" to "New recipe".** This change is inline with Obsidian's native context menu actions, which read "New note", "New folder", etc.
2. **The action no longer shows up when right-clicking a file.** This is also inline with Obsidian's native context menu actions, which only show up when clicking a folder or empty space.
3. **The action is grouped alongside the other similar context menu items.** Attached are screenshots which illustrate what this change means.

<img width="391" height="374" alt="image" src="https://github.com/user-attachments/assets/fa864c17-f3a1-4a56-b13e-7bd26c4d22b8" />
<img width="391" height="374" alt="image" src="https://github.com/user-attachments/assets/f6b99e5e-182f-4c38-9139-33bba52ef6a9" />
<img width="405" height="563" alt="image" src="https://github.com/user-attachments/assets/3dd03ca6-5485-4c22-9022-fefad06a7f62" />
