### PR TITLE
Fix: multiple broken and unused settings

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -105,7 +105,6 @@ export class CookView extends TextFileView {
             lineNumbers(),
             highlightActiveLine(),
             cooklang, // Our custom Cooklang language support
-            EditorView.lineWrapping,
             // Add theme-aware syntax highlighting
             isDark ?
                 syntaxHighlighting(defaultHighlightStyle) :
@@ -121,6 +120,11 @@ export class CookView extends TextFileView {
                 }
             ])
         ];
+
+        // Add `EditorView.lineWrapping` if the `lineWrap` setting is enabled.
+        if (this.settings.lineWrap) {
+            extensions.push(EditorView.lineWrapping);
+        }
 
         // Add oneDark theme only in dark mode
         if (isDark) {

--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -48,12 +48,15 @@ export class CookView extends TextFileView {
         this.parserReady = parserService.initialize();
 
         // Initialize timer service
-        this.timerService = new TimerService({
-            tickSoundUrl: timerMp3,
-            alarmSoundUrl: alarmMp3,
-            tickVolume: 0.3,
-            alarmVolume: 0.3
-        });
+        this.timerService = new TimerService(
+            this.settings,
+            {
+                tickSoundUrl: timerMp3,
+                alarmSoundUrl: alarmMp3,
+                tickVolume: 0.3,
+                alarmVolume: 0.3
+            },
+        );
 
         // Initialize preview renderer
         this.previewRenderer = new PreviewRenderer(

--- a/src/renderers/MethodStepsRenderer.ts
+++ b/src/renderers/MethodStepsRenderer.ts
@@ -126,25 +126,31 @@ export class MethodStepsRenderer {
         unitMap: Record<string, number>
     ): void {
         span.addClass('timer');
-        const button = span.createEl('button', { cls: 'timer-button' });
-        button.appendText('⏲');
+
+        // If `showTimersInline` is true nest everything in a button element.
+        if (this.settings.showTimersInline) {
+            span = span.createEl('button', { cls: 'timer-button' });
+        }
+        span.appendText('⏲');
 
         const numericQty = getQuantityValue(timer.quantity);
         if (numericQty !== null) {
-            button.appendText(' ');
+            span.appendText(' ');
             const unit = timer.quantity?.unit;
             const multiplier = unit ? unitMap[unit.toLowerCase()] ?? 1 : 1;
             const seconds = numericQty * multiplier;
 
-            button.createEl('span', { cls: 'amount', text: formatTime(seconds) });
+            span.createEl('span', { cls: 'amount', text: formatTime(seconds) });
 
-            // Attach timer functionality to button
-            this.timerService.attachTimerToButton(button, seconds, timer.name ?? '');
+            // Attach timer functionality if the element is a button.
+            if (span instanceof HTMLButtonElement) {
+                this.timerService.attachTimerToButton(span, seconds, timer.name ?? '');
+            }
         }
 
         if (timer.name) {
-            button.appendText(' ');
-            button.createEl('span', { cls: 'name', text: timer.name });
+            span.appendText(' ');
+            span.createEl('span', { cls: 'name', text: timer.name });
         }
     }
 }

--- a/src/renderers/MethodStepsRenderer.ts
+++ b/src/renderers/MethodStepsRenderer.ts
@@ -85,7 +85,7 @@ export class MethodStepsRenderer {
             span.addClass('ingredient-highlight')
         }
 
-        if (ingredient.quantity) {
+        if (this.settings.showQuantitiesInline && ingredient.quantity) {
             span.appendText(' (');
             span.createEl('span', {
                 cls: 'amount',

--- a/src/services/TimerService.ts
+++ b/src/services/TimerService.ts
@@ -9,6 +9,7 @@
 import { Howl } from 'howler';
 import { Notice } from 'obsidian';
 import { formatTime } from '../utils/timeFormatters';
+import { CooklangSettings } from 'src/settings';
 
 /**
  * Timer state data
@@ -42,9 +43,10 @@ export class TimerService {
 
     /**
      * Create a new TimerService
+     * @param settings - Plugin settings
      * @param config - Configuration with sound URLs and volumes
      */
-    constructor(config: TimerServiceConfig) {
+    constructor(private settings: CooklangSettings, config: TimerServiceConfig) {
         this.tickSound = new Howl({
             src: [config.tickSoundUrl],
             volume: config.tickVolume ?? 0.3
@@ -200,14 +202,14 @@ export class TimerService {
      * Play tick sound
      */
     public playTick(): void {
-        this.tickSound.play();
+        if (this.settings.timersTick) this.tickSound.play();
     }
 
     /**
      * Play alarm sound
      */
     public playAlarm(): void {
-        this.alarmSound.play();
+        if (this.settings.timersRing) this.alarmSound.play();
     }
 
     /**


### PR DESCRIPTION
From my testing I have found six settings that currently do nothing but seemingly worked in the past.
 - `showTotalTime`
 - `showTimersInline`
 - `showQuantitiesInline`
 - `timersTick`
 - `timersRing`
 - `lineWrap`
 
This PR fixes all but the first which requires some decision making about how to show the total time and is not a simple fix like the others.

## [`showTimersInline`](https://github.com/cooklang/cooklang-obsidian/commit/042b08163ea9b86a5b176e5350990537ddbb6e31)
This fix doesn't involve changing most of the logic in [`renderInlineTimer`](https://github.com/cooklang/cooklang-obsidian/blob/6383c3744b2128a997271413f390c2804273f1e9/src/renderers/MethodStepsRenderer.ts#L123) and instead the element being modified can be selectively made into a button depending on if the user wants the timer to be an interactive button. Attaching the timer service can be decided by whether the element is a button or not.

| Setting enabled | Setting disabled |
| ------------------------- | -------------------- |
| <img width="355" height="156" alt="image" src="https://github.com/user-attachments/assets/39a88438-5706-43dc-bb6c-8ec0c56eab63" /> | <img width="355" height="156" alt="image" src="https://github.com/user-attachments/assets/8a224ca8-37c7-47ea-af39-7f46768b926f" /> |


## [`showQuantitiesInline`](https://github.com/cooklang/cooklang-obsidian/commit/935fcdb3f8a8f633637d5a3c7cfbb75223485db4)
This is a single line fix. The code for displaying quantities inline is already encapsulated so all it takes is expanding the requirements to also check the relevant setting.

| Setting enabled | Setting disabled |
| ------------------------- | -------------------- |
| <img width="471" height="156" alt="image" src="https://github.com/user-attachments/assets/c465727b-ad62-4f2e-9fda-3d5caa7d6dc8" /> | <img width="471" height="156" alt="image" src="https://github.com/user-attachments/assets/cf345f28-fe95-4fe3-93c6-a53903303cc6" /> |

## [`timersTick` and `timersRing`](https://github.com/cooklang/cooklang-obsidian/commit/536af73ec960fc08cde309dc845618dff0a9b777)
The functions [`playTick`](https://github.com/cooklang/cooklang-obsidian/blob/6383c3744b2128a997271413f390c2804273f1e9/src/services/TimerService.ts#L202) and [`playAlarm`](https://github.com/cooklang/cooklang-obsidian/blob/6383c3744b2128a997271413f390c2804273f1e9/src/services/TimerService.ts#L209) can be modified to do nothing if the user has disabled the `timersTick` and `timersRing` setting respectively. This requires passing `CooklangSettings` to the service. In my testing the setting changes update timer behavior instantly, even updating currently running timers.

## [`lineWrap`](https://github.com/cooklang/cooklang-obsidian/commit/5251b13d7155e1303d236486dff20202065b4c68)
Line wrapping in the editor view is done with the inclusion of the `EditorView.lineWrapping` extension. This can be selectively disabled and enabled based off the user's preference.

| Setting enabled | Setting disabled |
| ------------------------- | -------------------- |
| <img width="940" height="372" alt="image" src="https://github.com/user-attachments/assets/99e5422f-f253-4f1a-8ab8-54f4132580c7" /> | <img width="940" height="372" alt="image" src="https://github.com/user-attachments/assets/3e58da4d-3bce-4bfa-bfdd-ea59995eb068" /> |