### PR TITLE
Feat: Group duplicate ingredients in ingredient list

### DIFF
--- a/src/recipeHelpers.ts
+++ b/src/recipeHelpers.ts
@@ -16,7 +16,9 @@ export {
     cookware_display_name
 } from '@cooklang/cooklang-ts';
 
-import type { CooklangRecipe } from '@cooklang/cooklang-ts';
+import type { CooklangRecipe, Ingredient } from '@cooklang/cooklang-ts';
+import { getQuantityValue, getQuantityUnit, quantity_display } from '@cooklang/cooklang-ts';
+import { formatNumber } from './utils/numberFormatters';
 
 /** Convert raw metadata Map to plain object */
 export function getMetadata(recipe: CooklangRecipe): Record<string, string> {
@@ -25,6 +27,74 @@ export function getMetadata(recipe: CooklangRecipe): Record<string, string> {
         metadata[String(key)] = String(value);
     });
     return metadata;
+}
+
+/** Ingredient with consolidated quantity across all uses in the recipe */
+export interface ConsolidatedIngredient {
+    name: string;
+    displayText: string | null;
+    isDivided: boolean;
+}
+
+/**
+ * Groups duplicate ingredient names and sums compatible quantities.
+ * Ingredients used more than once are marked as divided.
+ * @param ingredients - Raw ingredient list from the parsed recipe
+ * @returns One entry per unique ingredient name
+ */
+export function consolidateIngredients(ingredients: Ingredient[]): ConsolidatedIngredient[] {
+    const groups = new Map<string, Ingredient[]>();
+
+    ingredients.forEach(ing => {
+        const name = ing.alias ?? ing.name;
+        if (!groups.has(name)) groups.set(name, []);
+        groups.get(name)!.push(ing);
+    });
+
+    const result: ConsolidatedIngredient[] = [];
+
+    groups.forEach((group, name) => {
+        const isDivided = group.length > 1;
+
+        if (!isDivided) {
+            const ing = group[0];
+            result.push({
+                name,
+                displayText: ing.quantity ? quantity_display(ing.quantity) : null,
+                isDivided: false
+            });
+            return;
+        }
+
+        // Group numeric quantities by unit, collect non-numeric display texts
+        const unitTotals = new Map<string | null, number>();
+        const fallbackTexts: string[] = [];
+
+        group.forEach(ing => {
+            if (!ing.quantity) return;
+            const num = getQuantityValue(ing.quantity);
+            const unit = getQuantityUnit(ing.quantity);
+            if (num !== null) {
+                unitTotals.set(unit, (unitTotals.get(unit) ?? 0) + num);
+            } else {
+                fallbackTexts.push(quantity_display(ing.quantity));
+            }
+        });
+
+        const parts: string[] = [];
+        unitTotals.forEach((total, unit) => {
+            parts.push(unit ? `${formatNumber(total)} ${unit}` : formatNumber(total));
+        });
+        parts.push(...fallbackTexts);
+
+        result.push({
+            name,
+            displayText: parts.length > 0 ? parts.join(', ') : null,
+            isDivided: true
+        });
+    });
+
+    return result;
 }
 
 /** Get all steps with their parts expanded */

--- a/src/renderers/IngredientListRenderer.ts
+++ b/src/renderers/IngredientListRenderer.ts
@@ -6,7 +6,7 @@
 
 import type { CooklangRecipe } from '@cooklang/cooklang-ts';
 import { CooklangSettings } from '../settings';
-import { getFlatIngredients } from '../recipeHelpers';
+import { consolidateIngredients } from '../recipeHelpers';
 
 /**
  * Renders recipe ingredients list section
@@ -22,7 +22,7 @@ export class IngredientListRenderer {
      * @param onToggle - Callback when ingredient is toggled
      */
     public render(
-        recipe: CooklangRecipe, 
+        recipe: CooklangRecipe,
         container: HTMLElement,
         checkedIngredients?: Set<string>,
         onToggle?: () => void
@@ -31,7 +31,7 @@ export class IngredientListRenderer {
             return; // Feature disabled
         }
 
-        const ingredients = getFlatIngredients(recipe);
+        const ingredients = consolidateIngredients(recipe.ingredients);
 
         if (!ingredients || ingredients.length === 0) {
             return; // No ingredients to render
@@ -48,12 +48,10 @@ export class IngredientListRenderer {
 
         ingredients.forEach(ingredient => {
             // Create unique ID for this ingredient
-            const ingredientId = `${ingredient.name}-${ingredient.displayText || 'none'}`;
+            const ingredientId = ingredient.name;
             const isChecked = checkedIngredients?.has(ingredientId) || false;
 
-            console.log('Rendering ingredient:', ingredientId, 'isChecked:', isChecked);
-
-            const li = ul.createEl('li', { 
+            const li = ul.createEl('li', {
                 cls: `cook-ingredient ${isChecked ? 'ingredient-checked' : ''}`
             });
 
@@ -69,12 +67,9 @@ export class IngredientListRenderer {
                 li.onclick = () => {
                     if (isChecked) {
                         checkedIngredients.delete(ingredientId);
-                        console.log('Unchecked:', ingredientId, 'Set now has:', checkedIngredients.size);
                     } else {
                         checkedIngredients.add(ingredientId);
-                        console.log('Checked:', ingredientId, 'Set now has:', checkedIngredients.size);
                     }
-                    console.log('Current checked ingredients:', Array.from(checkedIngredients));
                     onToggle();
                 };
             }
@@ -87,6 +82,11 @@ export class IngredientListRenderer {
 
             // Add ingredient name
             li.appendText(ingredient.name);
+
+            // Add divided label if ingredient is used in multiple steps
+            if (ingredient.isDivided) {
+                li.appendText(', divided');
+            }
         });
     }
 }

--- a/src/utils/numberFormatters.ts
+++ b/src/utils/numberFormatters.ts
@@ -1,0 +1,29 @@
+/**
+ * Number formatting utilities
+ */
+
+/**
+ * Formats a number as an integer or simple fraction string
+ * @param n - The number to format
+ * @returns Formatted string (e.g., "5", "1/2", "1 3/4")
+ *
+ * @example
+ * formatNumber(5)    // "5"
+ * formatNumber(0.5)  // "1/2"
+ * formatNumber(1.75) // "1 3/4"
+ */
+export function formatNumber(n: number): string {
+    if (Number.isInteger(n)) return String(n);
+    const denominators = [2, 3, 4, 6, 8];
+    for (const d of denominators) {
+        const numerator = Math.round(n * d);
+        if (Math.abs(numerator / d - n) < 0.001) {
+            const whole = Math.floor(numerator / d);
+            const rem = numerator % d;
+            if (rem === 0) return String(whole);
+            if (whole === 0) return `${rem}/${d}`;
+            return `${whole} ${rem}/${d}`;
+        }
+    }
+    return parseFloat(n.toFixed(2)).toString();
+}


### PR DESCRIPTION
Ingredients that appear multiple times in a recipe are now consolidated into a single list entry with their quantities summed and a ", divided" label appended.

Resolves #8