### PR TITLE
Combine same-name ingredients & link recipe references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Ingredient list now combines the same ingredient listed multiple times into one
+  row, summing quantities that share a unit (different units shown side by side;
+  ranges/textual amounts listed as-is).
+- Recipe references (`@./Components/Beans`) render as clickable links to the
+  referenced `.cook` file — both in the ingredient list and inline in the steps —
+  falling back to plain text when the target isn't found.
+
 ## 0.7.0
 
 ### Added

--- a/src/renderers/IngredientListRenderer.ts
+++ b/src/renderers/IngredientListRenderer.ts
@@ -1,29 +1,34 @@
 /**
  * IngredientListRenderer — a single combined ingredient checklist for the whole
- * recipe (CookCLI-style). Duplicate ingredients are merged and their quantities
- * summed by the parser's own grouping (`recipe.groupedIngredients`), which
- * handles fractions and mixed units (e.g. "1 cup + 2 tbsp"). Quantities reflect
- * the already-scaled recipe (CookView re-parses with scale). Checkboxes are
- * keyed by ingredient name so scaling / re-render preserves checked state.
+ * recipe. Rows are merged by name and quantities summed per unit (see
+ * aggregateIngredients); recipe references render as links to the target recipe.
+ * Quantities reflect the already-scaled recipe (CookView re-parses with scale).
+ * Checkboxes are keyed by ingredient name so scaling / re-render preserves state.
  */
+import { App } from 'obsidian';
 import { CooklangSettings } from '../settings';
 import {
     ingredient_should_be_listed,
     ingredient_display_name,
-    grouped_quantity_is_empty,
-    grouped_quantity_display,
+    getQuantityValue,
+    getQuantityUnit,
+    quantity_display,
 } from '../recipeHelpers';
+import { aggregateIngredients, type AggInput } from '../utils/ingredientAggregator';
+import { renderReferenceLink } from './referenceLink';
 import type { RenderContext } from './types';
 
 export class IngredientListRenderer {
-    constructor(private settings: CooklangSettings) {}
+    constructor(private app: App, private settings: CooklangSettings) {}
 
     render(container: HTMLElement, ctx: RenderContext): void {
         if (!this.settings.showIngredientList) return;
 
-        const grouped = ctx.recipe.groupedIngredients
-            .filter(([ingredient]) => ingredient_should_be_listed(ingredient));
-        if (!grouped.length) return;
+        const inputs: AggInput[] = ctx.recipe.ingredients
+            .filter((ing: any) => ingredient_should_be_listed(ing))
+            .map((ing: any) => this.toAggInput(ing));
+        const rows = aggregateIngredients(inputs);
+        if (!rows.length) return;
 
         const region = container.createDiv({ cls: 'cook-ingredients' });
         region.id = 'cook-ingredients';
@@ -35,23 +40,57 @@ export class IngredientListRenderer {
         const ul = region.createEl('ul', { cls: 'cook-ing-list' });
         const checked = ctx.state.checkedIngredients;
 
-        for (const [ingredient, quantity] of grouped) {
-            const name = ingredient_display_name(ingredient);
-            const isChecked = checked.has(name);
-
+        for (const row of rows) {
+            const isChecked = checked.has(row.name);
             const li = ul.createEl('li', { cls: isChecked ? 'cook-ing done' : 'cook-ing' });
             li.createSpan({ cls: 'cook-ing-box' });
-            li.createSpan({ cls: 'cook-ing-name', text: name });
 
-            if (!grouped_quantity_is_empty(quantity)) {
-                li.createSpan({ cls: 'cook-ing-qty', text: grouped_quantity_display(quantity) });
+            const nameEl = li.createSpan({ cls: 'cook-ing-name' });
+            if (row.reference) {
+                renderReferenceLink(this.app, ctx.file, row.reference, nameEl);
+            } else {
+                nameEl.setText(row.name);
             }
 
-            li.addEventListener('click', () => {
-                if (checked.has(name)) checked.delete(name);
-                else checked.add(name);
+            if (row.displayQty) {
+                li.createSpan({ cls: 'cook-ing-qty', text: row.displayQty });
+            }
+
+            li.addEventListener('click', (e) => {
+                // Ignore clicks on the reference link itself.
+                if ((e.target as HTMLElement).closest('a')) return;
+                if (checked.has(row.name)) checked.delete(row.name);
+                else checked.add(row.name);
                 ctx.callbacks.onIngredientToggle();
             });
         }
+    }
+
+    private toAggInput(ing: any): AggInput {
+        const q = ing.quantity;
+        let quantityValue: number | null = null;
+        let unit: string | null = null;
+        let quantityText: string | null = null;
+
+        if (q) {
+            if (q.value?.type === 'number') {
+                quantityValue = getQuantityValue(q);
+                unit = getQuantityUnit(q);
+            } else {
+                // range or text amount — show as-is, don't sum
+                quantityText = quantity_display(q);
+            }
+        }
+
+        return {
+            name: ingredient_display_name(ing),
+            quantityValue,
+            unit,
+            quantityText,
+            note: ing.note ?? null,
+            reference: ing.reference
+                ? { name: ing.reference.name, components: ing.reference.components ?? [] }
+                : null,
+        };
     }
 }

--- a/src/renderers/IngredientListRenderer.ts
+++ b/src/renderers/IngredientListRenderer.ts
@@ -10,10 +10,9 @@ import { CooklangSettings } from '../settings';
 import {
     ingredient_should_be_listed,
     ingredient_display_name,
-    getQuantityValue,
-    getQuantityUnit,
     quantity_display,
 } from '../recipeHelpers';
+import { numericFromQuantity } from '../utils/quantityValue';
 import { aggregateIngredients, type AggInput } from '../utils/ingredientAggregator';
 import { renderReferenceLink } from './referenceLink';
 import type { RenderContext } from './types';
@@ -73,9 +72,10 @@ export class IngredientListRenderer {
         let quantityText: string | null = null;
 
         if (q) {
-            if (q.value?.type === 'number') {
-                quantityValue = getQuantityValue(q);
-                unit = getQuantityUnit(q);
+            const num = numericFromQuantity(q);
+            if (num !== null) {
+                quantityValue = num;
+                unit = q.unit ?? null; // author's unit ("cups"), not the abbreviated canonical form
             } else {
                 // range or text amount — show as-is, don't sum
                 quantityText = quantity_display(q);

--- a/src/renderers/MethodStepsRenderer.ts
+++ b/src/renderers/MethodStepsRenderer.ts
@@ -14,6 +14,7 @@ import {
 import { formatTime, createUnitMap } from '../utils/timeFormatters';
 import type { SectionView, StepView, StepPart } from '../utils/sectionHelpers';
 import { getStepImageFor } from '../utils/stepImages';
+import { renderReferenceLink } from './referenceLink';
 import type { RenderContext } from './types';
 
 export class MethodStepsRenderer {
@@ -79,7 +80,7 @@ export class MethodStepsRenderer {
 
         const bodyWrap = li.createDiv({ cls: 'cook-step-bodywrap' });
         const body = bodyWrap.createDiv({ cls: 'cook-step-text' });
-        step.parts.forEach(part => this.renderPart(body, part, unitMap));
+        step.parts.forEach(part => this.renderPart(body, part, unitMap, file));
 
         // Per-step image
         if (this.settings.showImages && file) {
@@ -97,7 +98,7 @@ export class MethodStepsRenderer {
         }
     }
 
-    private renderPart(body: HTMLElement, part: StepPart, unitMap: Record<string, number>): void {
+    private renderPart(body: HTMLElement, part: StepPart, unitMap: Record<string, number>, file: TFile | null): void {
         if (part.type === 'text') {
             body.appendText(part.value);
             return;
@@ -105,8 +106,14 @@ export class MethodStepsRenderer {
         const span = body.createEl('span');
         if (part.type === 'ingredient') {
             span.addClass('cook-ig');
-            span.appendText(ingredient_display_name(part.ingredient));
-            if (this.settings.highlightIngredientCookware) span.addClass('cook-ig-hl');
+            const ref = (part.ingredient as any).reference;
+            if (ref) {
+                renderReferenceLink(this.app, file,
+                    { name: ref.name, components: ref.components ?? [] }, span);
+            } else {
+                span.appendText(ingredient_display_name(part.ingredient));
+                if (this.settings.highlightIngredientCookware) span.addClass('cook-ig-hl');
+            }
             if (this.settings.showQuantitiesInline && part.ingredient.quantity) {
                 span.appendText(' ');
                 span.createEl('span', {

--- a/src/renderers/PreviewRenderer.ts
+++ b/src/renderers/PreviewRenderer.ts
@@ -39,7 +39,7 @@ export class PreviewRenderer {
     private buildRenderers(): void {
         this.hero = new HeroRenderer(this.app, this.settings);
         this.scalerBar = new ScalerBarRenderer(this.settings);
-        this.ingredientRenderer = new IngredientListRenderer(this.settings);
+        this.ingredientRenderer = new IngredientListRenderer(this.app, this.settings);
         this.cookwareRenderer = new CookwareListRenderer(this.settings);
         this.timerListRenderer = new TimerListRenderer(this.settings);
         this.methodStepsRenderer = new MethodStepsRenderer(this.app, this.settings, this.timerService);

--- a/src/renderers/referenceLink.ts
+++ b/src/renderers/referenceLink.ts
@@ -1,0 +1,35 @@
+/**
+ * Renders a Cooklang recipe reference (e.g. `@./Components/Beans`) as a link to
+ * the referenced `.cook` file. If the target file can't be found in the vault,
+ * it falls back to plain styled text (no dead link).
+ */
+import { App, TFile } from 'obsidian';
+import { resolveReferencePath } from '../utils/recipeReferences';
+import type { RecipeRefTarget } from '../utils/ingredientAggregator';
+
+export function renderReferenceLink(
+    app: App,
+    sourceFile: TFile | null,
+    ref: RecipeRefTarget,
+    parent: HTMLElement,
+): void {
+    const folder = sourceFile?.parent?.path ?? '';
+    const normalizedFolder = folder === '/' ? '' : folder;
+    const targetPath = resolveReferencePath(normalizedFolder, ref.components ?? [], ref.name);
+    const target = app.vault.getAbstractFileByPath(targetPath);
+
+    if (target instanceof TFile) {
+        const link = parent.createEl('a', {
+            cls: 'cook-ref-link',
+            text: ref.name,
+            href: '#',
+        });
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation(); // don't trigger ingredient/step toggles
+            app.workspace.openLinkText(target.path, sourceFile?.path ?? '', false);
+        });
+    } else {
+        parent.createSpan({ cls: 'cook-ref-missing', text: ref.name });
+    }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -320,6 +320,17 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-step-image { margin-top: var(--size-4-2, 8px); }
 .cook-step-image img { max-width: 100%; border-radius: var(--radius-m, 8px); }
 
+/* Recipe reference links */
+.cook-ref-link {
+  color: var(--link-color, var(--text-accent));
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.cook-ref-link:hover { text-decoration-style: solid; }
+.cook-ref-missing { color: var(--text-muted); font-style: italic; }
+
 /* Inline components */
 .cook-ig-hl { color: var(--color-green, var(--text-accent)); font-weight: 600; }
 .cook-cw-hl { color: var(--color-orange, var(--text-accent)); font-weight: 600; }

--- a/src/utils/ingredientAggregator.test.ts
+++ b/src/utils/ingredientAggregator.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateIngredients, formatQuantity, type AggInput } from './ingredientAggregator';
+
+function ing(partial: Partial<AggInput>): AggInput {
+    return {
+        name: 'x', quantityValue: null, unit: null,
+        quantityText: null, note: null, reference: null, ...partial,
+    };
+}
+
+describe('formatQuantity', () => {
+    it('rounds to 2 decimals and drops trailing zeros', () => {
+        expect(formatQuantity(5.6667)).toBe('5.67');
+        expect(formatQuantity(16.5)).toBe('16.5');
+        expect(formatQuantity(11)).toBe('11');
+    });
+});
+
+describe('aggregateIngredients', () => {
+    it('sums quantities sharing a unit, treating cup/cups as one', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'all-purpose flour', quantityValue: 5, unit: 'cups' }),
+            ing({ name: 'all-purpose flour', quantityValue: 2 / 3, unit: 'cup' }),
+            ing({ name: 'all-purpose flour' }), // no amount
+        ]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].displayQty).toBe('5.67 cups');
+    });
+
+    it('shows different units side by side', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'egg yolks', quantityValue: 7, unit: null }),
+            ing({ name: 'egg yolks', quantityValue: 4, unit: 'large' }),
+        ]);
+        expect(rows[0].displayQty).toBe('7 + 4 large');
+    });
+
+    it('lists range/textual amounts as-is', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'sugar', quantityText: '1.5-2.25 cups' }),
+            ing({ name: 'sugar', quantityValue: 1, unit: 'cup' }),
+        ]);
+        expect(rows[0].displayQty).toBe('1 cup + 1.5-2.25 cups');
+    });
+
+    it('keeps distinct names separate and preserves first-seen order', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'butter', quantityValue: 1, unit: 'sticks' }),
+            ing({ name: 'flour', quantityValue: 2, unit: 'cups' }),
+            ing({ name: 'butter', quantityValue: 2, unit: 'sticks' }),
+        ]);
+        expect(rows.map(r => r.name)).toEqual(['butter', 'flour']);
+        // unit display comes from the first occurrence in the group
+        expect(rows[0].displayQty).toBe('3 sticks');
+    });
+
+    it('null displayQty when no amounts', () => {
+        const rows = aggregateIngredients([ing({ name: 'salt' })]);
+        expect(rows[0].displayQty).toBeNull();
+    });
+
+    it('carries the first reference and note found', () => {
+        const ref = { name: 'Beans', components: ['.', 'Components'] };
+        const rows = aggregateIngredients([
+            ing({ name: 'Beans', quantityValue: 2, unit: 'servings', reference: ref, note: 'warm' }),
+        ]);
+        expect(rows[0].reference).toEqual(ref);
+        expect(rows[0].note).toBe('warm');
+        expect(rows[0].displayQty).toBe('2 servings');
+    });
+});

--- a/src/utils/ingredientAggregator.ts
+++ b/src/utils/ingredientAggregator.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure by-name ingredient aggregation (CookCLI shopping-list style).
+ *
+ * The parser's group_ingredients only merges *references* into their definition;
+ * it leaves separate same-name definitions apart (e.g. `@flour{5%cups}` written
+ * twice = two entries). This merges rows by display name and sums quantities
+ * that share a unit. Different units are shown side by side ("5 cups + 2 tbsp");
+ * ranges / textual amounts are listed as-is. No cross-unit conversion.
+ */
+
+export interface RecipeRefTarget {
+    /** Display name of the referenced recipe (e.g. "Beans"). */
+    name: string;
+    /** Path components from the reference, e.g. [".", "Components"]. */
+    components: string[];
+}
+
+export interface AggInput {
+    name: string;
+    /** Numeric quantity when the amount is a plain number; null otherwise. */
+    quantityValue: number | null;
+    /** Unit string for a numeric quantity, or null. */
+    unit: string | null;
+    /** Pre-formatted text for non-summable amounts (ranges/text), else null. */
+    quantityText: string | null;
+    note: string | null;
+    /** Present when this ingredient is a recipe reference. */
+    reference: RecipeRefTarget | null;
+}
+
+export interface IngredientRow {
+    name: string;
+    /** Combined quantity text, or null when there's no amount. */
+    displayQty: string | null;
+    note: string | null;
+    reference: RecipeRefTarget | null;
+}
+
+/** Round to 2 decimals and drop trailing zeros: 5.6667 -> "5.67", 16.5 -> "16.5". */
+export function formatQuantity(n: number): string {
+    return String(Math.round(n * 100) / 100);
+}
+
+/** Group key that treats "cup"/"cups" as the same unit. */
+function unitKey(unit: string | null): string {
+    return (unit ?? '').trim().toLowerCase().replace(/s$/, '');
+}
+
+export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
+    const order: string[] = [];
+    const groups = new Map<string, {
+        name: string;
+        units: Map<string, { sum: number; unitDisplay: string }>;
+        unitOrder: string[];
+        textParts: string[];
+        note: string | null;
+        reference: RecipeRefTarget | null;
+    }>();
+
+    for (const item of items) {
+        let group = groups.get(item.name);
+        if (!group) {
+            group = {
+                name: item.name,
+                units: new Map(),
+                unitOrder: [],
+                textParts: [],
+                note: null,
+                reference: null,
+            };
+            groups.set(item.name, group);
+            order.push(item.name);
+        }
+
+        if (item.quantityValue !== null) {
+            const key = unitKey(item.unit);
+            let bucket = group.units.get(key);
+            if (!bucket) {
+                bucket = { sum: 0, unitDisplay: item.unit ?? '' };
+                group.units.set(key, bucket);
+                group.unitOrder.push(key);
+            }
+            bucket.sum += item.quantityValue;
+        } else if (item.quantityText) {
+            group.textParts.push(item.quantityText);
+        }
+
+        if (group.note === null && item.note) group.note = item.note;
+        if (group.reference === null && item.reference) group.reference = item.reference;
+    }
+
+    return order.map(name => {
+        const group = groups.get(name)!;
+        const parts: string[] = [];
+        for (const key of group.unitOrder) {
+            const bucket = group.units.get(key)!;
+            parts.push(bucket.unitDisplay
+                ? `${formatQuantity(bucket.sum)} ${bucket.unitDisplay}`
+                : formatQuantity(bucket.sum));
+        }
+        parts.push(...group.textParts);
+        return {
+            name: group.name,
+            displayQty: parts.length ? parts.join(' + ') : null,
+            note: group.note,
+            reference: group.reference,
+        };
+    });
+}

--- a/src/utils/quantityValue.test.ts
+++ b/src/utils/quantityValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { numericFromQuantity } from './quantityValue';
+
+const regular = (n: number) => ({ value: { type: 'number', value: { type: 'regular', value: n } } });
+const fraction = (whole: number, num: number, den: number) =>
+    ({ value: { type: 'number', value: { type: 'fraction', value: { whole, num, den, err: 0 } } } });
+
+describe('numericFromQuantity', () => {
+    it('reads regular numbers (including decimals)', () => {
+        expect(numericFromQuantity(regular(5.5))).toBe(5.5);
+        expect(numericFromQuantity(regular(2))).toBe(2);
+    });
+
+    it('reads fractions', () => {
+        expect(numericFromQuantity(fraction(0, 2, 3))).toBeCloseTo(0.6667, 4);
+        expect(numericFromQuantity(fraction(0, 1, 8))).toBe(0.125);
+        expect(numericFromQuantity(fraction(1, 1, 2))).toBe(1.5);
+    });
+
+    it('returns null for ranges, text, and missing quantities', () => {
+        expect(numericFromQuantity({ value: { type: 'range', value: {} } })).toBeNull();
+        expect(numericFromQuantity({ value: { type: 'text', value: 'a pinch' } })).toBeNull();
+        expect(numericFromQuantity(null)).toBeNull();
+        expect(numericFromQuantity(undefined)).toBeNull();
+    });
+
+    it('returns null for a zero denominator', () => {
+        expect(numericFromQuantity(fraction(0, 1, 0))).toBeNull();
+    });
+});

--- a/src/utils/quantityValue.ts
+++ b/src/utils/quantityValue.ts
@@ -1,0 +1,30 @@
+/**
+ * Extract a numeric value from a raw WASM Quantity.
+ *
+ * The library's getQuantityValue returns NaN for fraction quantities because a
+ * fraction's value is an object ({whole, num, den}), not a number. This reads
+ * both representations:
+ *   regular:  { type: 'number', value: { type: 'regular',  value: 5.5 } }
+ *   fraction: { type: 'number', value: { type: 'fraction', value: { whole, num, den } } }
+ * Range / text quantities return null (they aren't summable).
+ *
+ * Duck-typed (`any`) so it can be unit-tested without the WASM runtime.
+ */
+export function numericFromQuantity(quantity: any): number | null {
+    const value = quantity?.value;
+    if (!value || value.type !== 'number') return null;
+
+    const inner = value.value;
+    if (inner?.type === 'regular') {
+        const n = Number(inner.value);
+        return Number.isFinite(n) ? n : null;
+    }
+    if (inner?.type === 'fraction') {
+        const f = inner.value;
+        if (f && typeof f.den === 'number' && f.den !== 0) {
+            const n = (f.whole ?? 0) + (f.num ?? 0) / f.den;
+            return Number.isFinite(n) ? n : null;
+        }
+    }
+    return null;
+}

--- a/src/utils/recipeReferences.test.ts
+++ b/src/utils/recipeReferences.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { resolveReferencePath } from './recipeReferences';
+
+describe('resolveReferencePath', () => {
+    it('resolves a "./Sub/Name" reference relative to the recipe folder', () => {
+        expect(resolveReferencePath('Breakfast', ['.', 'Components'], 'Beans'))
+            .toBe('Breakfast/Components/Beans.cook');
+    });
+
+    it('resolves a same-folder reference', () => {
+        expect(resolveReferencePath('Breakfast', ['.'], 'Salsa'))
+            .toBe('Breakfast/Salsa.cook');
+    });
+
+    it('handles parent navigation with ".."', () => {
+        expect(resolveReferencePath('Breakfast/Quick', ['..', 'Sauces'], 'Aioli'))
+            .toBe('Breakfast/Sauces/Aioli.cook');
+    });
+
+    it('works from the vault root', () => {
+        expect(resolveReferencePath('', ['.'], 'Beans'))
+            .toBe('Beans.cook');
+    });
+
+    it('ignores empty/dot components', () => {
+        expect(resolveReferencePath('A', [], 'B')).toBe('A/B.cook');
+    });
+});

--- a/src/utils/recipeReferences.ts
+++ b/src/utils/recipeReferences.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure resolution of Cooklang recipe references to a vault path.
+ *
+ * A reference like `@./Components/Beans` parses to
+ * { name: "Beans", components: [".", "Components"] }. The components are a path
+ * relative to the referencing recipe's own folder; "." stays, ".." goes up.
+ * This resolves that to a concrete `<...>.cook` vault path.
+ */
+
+/**
+ * Resolve a reference to a `.cook` vault path, relative to the folder of the
+ * recipe that contains the reference.
+ *
+ * @param recipeFolder - Vault path of the referencing recipe's folder ('' = root)
+ * @param components - Reference path components (e.g. [".", "Components"])
+ * @param name - Referenced recipe name (e.g. "Beans")
+ * @returns Normalised vault path like "Breakfast/Components/Beans.cook"
+ */
+export function resolveReferencePath(
+    recipeFolder: string,
+    components: string[],
+    name: string,
+): string {
+    const segments = recipeFolder ? recipeFolder.split('/').filter(Boolean) : [];
+
+    for (const component of components) {
+        if (component === '' || component === '.') continue;
+        if (component === '..') {
+            segments.pop();
+        } else {
+            segments.push(component);
+        }
+    }
+    segments.push(name);
+
+    return segments.join('/') + '.cook';
+}


### PR DESCRIPTION
## Summary

Two preview refinements from testing real recipes:

- **Combine same-name ingredients.** The parser's `group_ingredients` only merges *references* into their definition, so an ingredient written as several separate definitions (e.g. `@all-purpose flour` listed 3× in `Napoleon.cook`) showed as 3 rows. The ingredient list is now aggregated by name, **summing quantities that share a unit** (`5 cups` + `2/3 cup` → `5.67 cups`). Different units are shown side by side (`7 + 4 large`); ranges/textual amounts are listed as-is. No cross-unit conversion.
- **Link recipe references.** Cooklang recipe references like `@./Components/Beans` now render as **clickable links** to the target `.cook` file — both in the ingredient list and inline in the steps — resolving the path relative to the current recipe's folder. Falls back to plain text when the target isn't found.

## Implementation

- New pure, unit-tested helpers: `ingredientAggregator.ts` (by-name sum) and `recipeReferences.ts` (reference → vault path), plus a shared `referenceLink.ts` renderer.
- `IngredientListRenderer` builds aggregator inputs from the raw (already-scaled) ingredients; `MethodStepsRenderer` linkifies inline references.

## Test plan

- [x] `npm test` — 36 unit tests pass (incl. new aggregator + reference-path suites)
- [x] `npm run build` — clean
- [x] Verified extraction in Node against the real `Napoleon.cook` (3 flour defs → one summed row) and `Mexican Style Burrito.cook` (Beans/Guacamole references)
- [ ] **Manual in Obsidian**: flour combines to one row; Beans/Guacamole are clickable and open the referenced recipes; inline references in steps link too; missing target → plain text