### PR TITLE
fix: correct servings scaling factor and reachable targets (#83)

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -12,7 +12,7 @@ import {string} from "postcss-selector-parser";
 import { parserService } from './services/ParserService';
 import { TimerService } from './services/TimerService';
 import { PreviewRenderer } from './renderers/PreviewRenderer';
-import { parseServingsValue, computeScale, clampServings } from './utils/scaling';
+import { parseServingsValue, computeScale, deriveServingsState } from './utils/scaling';
 import alarmMp3 from './alarm.mp3';
 import timerMp3 from './timer.mp3';
 
@@ -352,10 +352,15 @@ export class CookView extends TextFileView {
         const [rawRecipe] = parserService.parse(this.data, this.scale);
         this.rawRecipe = rawRecipe;
 
-        const baseServings = parseServingsValue(rawRecipe.servings);
-        const displayServings = baseServings != null
-            ? clampServings(baseServings * this.scale)
-            : null;
+        // The parser scales (and rounds) the `servings` metadata, so the servings
+        // on `rawRecipe` already reflect `this.scale`. Read the unscaled base from
+        // a scale-1 parse to compute scale targets and the displayed count
+        // correctly (see issue #83).
+        const [baseRecipe] = parserService.parse(this.data);
+        const { baseServings, displayServings } = deriveServingsState(
+            parseServingsValue(baseRecipe.servings),
+            this.scale,
+        );
 
         this.previewRenderer.updateSettings(this.settings);
         this.previewRenderer.render(this.previewEl, this.file, {

--- a/src/utils/scaling.test.ts
+++ b/src/utils/scaling.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseServingsValue, computeScale, clampServings } from './scaling';
+import { parseServingsValue, computeScale, clampServings, deriveServingsState } from './scaling';
 
 describe('parseServingsValue', () => {
     it('accepts positive numbers', () => {
@@ -31,5 +31,35 @@ describe('clampServings', () => {
         expect(clampServings(3.6)).toBe(4);
         expect(clampServings(0)).toBe(1);
         expect(clampServings(99999)).toBe(1000);
+    });
+});
+
+describe('deriveServingsState', () => {
+    it('displays base * scale, not base * scale^2', () => {
+        // Regression for #83: base servings must be the UNSCALED count.
+        // Scaling 1 serving by 4 must display 4 servings (with ingredients x4),
+        // never 2 (which is what squaring the scale produced).
+        expect(deriveServingsState(1, 4)).toEqual({ baseServings: 1, displayServings: 4 });
+        expect(deriveServingsState(1, 1)).toEqual({ baseServings: 1, displayServings: 1 });
+        expect(deriveServingsState(2, 3)).toEqual({ baseServings: 2, displayServings: 6 });
+    });
+
+    it('rounds and clamps the display to a positive integer', () => {
+        expect(deriveServingsState(3, 0.5)).toEqual({ baseServings: 3, displayServings: 2 });
+        expect(deriveServingsState(1, 0.1)).toEqual({ baseServings: 1, displayServings: 1 });
+    });
+
+    it('returns nulls when there is no numeric base', () => {
+        expect(deriveServingsState(null, 4)).toEqual({ baseServings: null, displayServings: null });
+    });
+
+    it('every integer serving target round-trips through computeScale', () => {
+        // The +/- stepper computes a new scale from an integer target; rendering
+        // that scale must display exactly that target (so no target is skipped).
+        const base = 1;
+        for (let target = 1; target <= 12; target++) {
+            const scale = computeScale(target, base);
+            expect(deriveServingsState(base, scale).displayServings).toBe(target);
+        }
     });
 });

--- a/src/utils/scaling.ts
+++ b/src/utils/scaling.ts
@@ -31,3 +31,24 @@ export function computeScale(targetServings: number, baseServings: number): numb
 export function clampServings(value: number, min = 1, max = 1000): number {
     return Math.max(min, Math.min(max, Math.round(value)));
 }
+
+export interface ServingsState {
+    /** Unscaled base servings from recipe metadata, or null when not numeric. */
+    baseServings: number | null;
+    /** Servings shown to the user at the current scale, or null when no base. */
+    displayServings: number | null;
+}
+
+/**
+ * Derive the servings shown in the scaler from the UNSCALED base servings and
+ * the current scale.
+ *
+ * `baseServings` must come from a scale-1 parse: the Cooklang parser scales (and
+ * rounds) the `servings` metadata, so reading servings off a recipe parsed at
+ * `scale` and multiplying by `scale` again squares the factor — the bug behind
+ * issue #83 (×4 only doubled quantities, and targets like ×2/×6 were skipped).
+ */
+export function deriveServingsState(baseServings: number | null, scale: number): ServingsState {
+    if (baseServings == null) return { baseServings: null, displayServings: null };
+    return { baseServings, displayServings: clampServings(baseServings * scale) };
+}


### PR DESCRIPTION
Fixes #83.

## Root cause

`renderPreview()` re-parsed the recipe **at the current scale**, then read `servings` off that result as if it were the *base*:

```ts
const [rawRecipe] = parserService.parse(this.data, this.scale);
const baseServings = parseServingsValue(rawRecipe.servings);   // already scaled!
const displayServings = clampServings(baseServings * this.scale); // scale applied twice
```

The Cooklang WASM parser **scales *and rounds* the `servings` metadata** (verified empirically: at scale 2 the recipe reports `servings: 2`). Multiplying by the scale again produced both reported bugs:

- **Wrong factor:** displayed servings = `base × scale²` while ingredients scaled only by `scale`, so "×4" only doubled quantities (the `√n` behaviour).
- **Unreachable targets:** the next `+`/`−` click derived its target and `computeScale` divisor from the already-scaled/rounded count, so the scale jumped erratically and skipped integers like ×2, ×6, ×7.

## Fix

- `cookView.ts`: read base servings from a **scale-1 parse** so it's the true unscaled count; display and scale targets derive from that.
- `scaling.ts`: add a pure, documented `deriveServingsState(baseServings, scale)` helper making the non-squared `display = clamp(base × scale)` relationship explicit.

## Verification

- Simulated the full `+`/`−` flow against the real parser: sequence is now `1,2,3,…` (every integer reachable, increments of 1, clamps at 1 going down), and ×4 gives ingredients ×4.
- Added regression tests in `scaling.test.ts`, including a round-trip check that every integer target 1–12 displays exactly that target. All 52 tests pass.
- `npm run build` succeeds.