### PR TITLE
ci: fix release-please version (0.4.4 → 0.8.1) by matching plain tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": false,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
Fixes the incorrect version proposed in #82 (release-please wanted to release **0.4.4**, a downgrade from the current 0.8.0).

## Root cause

The repo's release tags are plain SemVer (`0.8.0`, `0.7.1`, …). But release-please derives its last-release lookup tag from the package **component** (the package name), so with `include-v-in-tag: false` it searched for `cooklang-obsidian-0.8.0` — which doesn't exist.

Dry-run output confirmed it:

```
⚠ Found release tag with component '', but not configured in manifest
❯ looking for tagName: cooklang-obsidian-0.8.0
⚠ Expected 1 releases, only found 0
```

With no recognizable previous release, release-please scanned the **entire** history and honored an ancient `Release-As: 0.4.4` footer (commit `ecc0868`, from around PR #46/#48), forcing the proposed version down to 0.4.4.

## Fix

Add `"include-component-in-tag": false` to `release-please-config.json`. The lookup/created tags become plain `X.Y.Z`, matching the existing tags.

## Verification

Dry-run against this branch:

```
❯ Found release for path ., 0.8.0
❯ release for path: ., version: 0.8.0, sha: c221f08
Would open 1 pull requests
title: chore(main): release 0.8.1
## [0.8.1](compare/0.8.0...0.8.1)
✔ updating from 0.8.0 to 0.8.1
```

It now scopes to commits since 0.8.0 and proposes **0.8.1** (driven by the `fix:` commits since the last release), ignoring the stale `Release-As` footer.

Once merged, the release-please action will update the release PR (#82) to propose 0.8.1.