### PR TITLE
feat: support markdown recipe references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Opening a `.cook` file and toggling Preview shows a single rich recipe page:
 Each of these can be toggled in the plugin settings (Servings scaler, Two-column layout,
 Step tracking), falling back to a simple stacked list.
 
+## Recipe references
+
+Reference another recipe with Cooklang ingredient syntax, for example
+`@./Components/Beans`. References resolve relative to the recipe containing
+them. The plugin opens a matching `.cook` file first, following the Cooklang
+convention. If no `.cook` file exists, it falls back to a same-path Markdown
+file only when its frontmatter contains the Boolean flag:
+
+```yaml
+---
+recipe: true
+---
+```
+
+This works in full recipe views and in embedded `cook`/`cooklang` blocks.
+
 ## Security
 > Third-party plugins can access files on your computer, connect to the internet, and even install additional programs.
 

--- a/src/renderers/referenceLink.ts
+++ b/src/renderers/referenceLink.ts
@@ -1,10 +1,11 @@
 /**
  * Renders a Cooklang recipe reference (e.g. `@./Components/Beans`) as a link to
- * the referenced `.cook` file. If the target file can't be found in the vault,
- * it falls back to plain styled text (no dead link).
+ * the referenced `.cook` file, or a same-path `.md` file marked `recipe: true`.
+ * If neither target can be found, it falls back to plain styled text (no dead
+ * link).
  */
 import { App, TFile } from 'obsidian';
-import { resolveReferencePath } from '../utils/recipeReferences';
+import { resolveReferenceCandidatePaths } from '../utils/recipeReferences';
 import type { RecipeRefTarget } from '../utils/ingredientAggregator';
 
 export function renderReferenceLink(
@@ -15,10 +16,21 @@ export function renderReferenceLink(
 ): void {
     const folder = sourceFile?.parent?.path ?? '';
     const normalizedFolder = folder === '/' ? '' : folder;
-    const targetPath = resolveReferencePath(normalizedFolder, ref.components ?? [], ref.name);
-    const target = app.vault.getAbstractFileByPath(targetPath);
+    const [cookPath, markdownPath] = resolveReferenceCandidatePaths(
+        normalizedFolder,
+        ref.components ?? [],
+        ref.name,
+    );
+    const cookTarget = app.vault.getAbstractFileByPath(cookPath);
+    const markdownTarget = app.vault.getAbstractFileByPath(markdownPath);
+    const target = cookTarget instanceof TFile
+        ? cookTarget
+        : markdownTarget instanceof TFile
+            && app.metadataCache.getFileCache(markdownTarget)?.frontmatter?.recipe === true
+            ? markdownTarget
+            : null;
 
-    if (target instanceof TFile) {
+    if (target) {
         const link = parent.createEl('a', {
             cls: 'cook-ref-link',
             text: ref.name,

--- a/src/utils/recipeReferences.test.ts
+++ b/src/utils/recipeReferences.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveReferencePath } from './recipeReferences';
+import { resolveReferenceCandidatePaths, resolveReferencePath } from './recipeReferences';
 
 describe('resolveReferencePath', () => {
     it('resolves a "./Sub/Name" reference relative to the recipe folder', () => {
@@ -24,5 +24,22 @@ describe('resolveReferencePath', () => {
 
     it('ignores empty/dot components', () => {
         expect(resolveReferencePath('A', [], 'B')).toBe('A/B.cook');
+    });
+});
+
+describe('resolveReferenceCandidatePaths', () => {
+    it('returns the .cook target before the same-path .md fallback', () => {
+        expect(resolveReferenceCandidatePaths('Breakfast', ['.', 'Components'], 'Beans'))
+            .toEqual(['Breakfast/Components/Beans.cook', 'Breakfast/Components/Beans.md']);
+    });
+
+    it('keeps parent navigation identical for both candidate extensions', () => {
+        expect(resolveReferenceCandidatePaths('Breakfast/Quick', ['..', 'Sauces'], 'Aioli'))
+            .toEqual(['Breakfast/Sauces/Aioli.cook', 'Breakfast/Sauces/Aioli.md']);
+    });
+
+    it('returns both candidates from the vault root', () => {
+        expect(resolveReferenceCandidatePaths('', ['.'], 'Beans'))
+            .toEqual(['Beans.cook', 'Beans.md']);
     });
 });

--- a/src/utils/recipeReferences.ts
+++ b/src/utils/recipeReferences.ts
@@ -4,7 +4,8 @@
  * A reference like `@./Components/Beans` parses to
  * { name: "Beans", components: [".", "Components"] }. The components are a path
  * relative to the referencing recipe's own folder; "." stays, ".." goes up.
- * This resolves that to a concrete `<...>.cook` vault path.
+ * This resolves that to concrete vault paths, with `.cook` remaining the
+ * primary Cooklang target and a `.md` recipe as a plugin-specific fallback.
  */
 
 /**
@@ -21,6 +22,28 @@ export function resolveReferencePath(
     components: string[],
     name: string,
 ): string {
+    return resolveReferenceBasePath(recipeFolder, components, name) + '.cook';
+}
+
+/**
+ * Resolve the ordered vault-path candidates for a recipe reference. `.cook`
+ * remains first to preserve the Cooklang convention; callers may use the
+ * `.md` path only when it is known to be a Cooklang recipe in Obsidian.
+ */
+export function resolveReferenceCandidatePaths(
+    recipeFolder: string,
+    components: string[],
+    name: string,
+): [cookPath: string, markdownPath: string] {
+    const basePath = resolveReferenceBasePath(recipeFolder, components, name);
+    return [basePath + '.cook', basePath + '.md'];
+}
+
+function resolveReferenceBasePath(
+    recipeFolder: string,
+    components: string[],
+    name: string,
+): string {
     const segments = recipeFolder ? recipeFolder.split('/').filter(Boolean) : [];
 
     for (const component of components) {
@@ -33,5 +56,5 @@ export function resolveReferencePath(
     }
     segments.push(name);
 
-    return segments.join('/') + '.cook';
+    return segments.join('/');
 }


### PR DESCRIPTION
## Overview

Cooklang recipe references currently resolve only to `.cook` files. The plugin also supports rendering Markdown recipes when their frontmatter contains `recipe: true`, so references should be able to navigate to those recipes without changing the upstream Cooklang parser.

This adds an Obsidian-side fallback: references continue to prefer the standard `.cook` target, then use a same-path Markdown file only when it is explicitly marked as a recipe. Existing unresolved-reference behavior is retained.

## Related Issue

None.

## Changes

- Resolve ordered `.cook` and `.md` candidate paths for recipe references
- Preserve `.cook` precedence when both target files exist
- Link to Markdown targets only when frontmatter has literal `recipe: true`
- Cover relative, parent, and vault-root candidate resolution
- Document reference syntax and Markdown fallback behavior

## Impact Scope

Recipe-reference rendering in rich recipe views and embedded `cook`/`cooklang` blocks. Existing `.cook` references remain unchanged.

## Checklist

- [x] Code follows the style guidelines
- [x] Tests have been added/updated
- [x] Documentation has been updated
- [x] Build is successful
- [x] Ready for review

## How to Test

- Run `npm test`
- Run `npm run build`
- In Obsidian, create `Components/Beans.md` with frontmatter `recipe: true`, then render `@./Components/Beans`; verify it opens the Markdown recipe.
- Add `Components/Beans.cook` and verify the `.cook` file is selected instead.

## Additional Information

The Cooklang parser and reference syntax are unchanged; the fallback is implemented solely in the Obsidian renderer.