### PR TITLE
fix: preserve inline Cooklang note order

### DIFF
--- a/src/renderers/MethodStepsRenderer.ts
+++ b/src/renderers/MethodStepsRenderer.ts
@@ -48,14 +48,14 @@ export class MethodStepsRenderer {
                 region.createEl('div', { cls: 'cook-section-band', text: section.name });
             }
 
-            section.steps.forEach(step => {
-                this.renderStep(region, step, ctx, unitMap, file, allImages);
-            });
-
-            section.notes.forEach(note => {
+            section.entries.forEach(entry => {
+                if (entry.type === 'step') {
+                    this.renderStep(region, entry.step, ctx, unitMap, file, allImages);
+                    return;
+                }
                 const callout = region.createDiv({ cls: 'cook-note' });
                 callout.createSpan({ cls: 'cook-note-icon', text: '💡' });
-                callout.createSpan({ cls: 'cook-note-text', text: note });
+                callout.createSpan({ cls: 'cook-note-text', text: entry.note });
             });
         });
     }

--- a/src/utils/ingredientSectionGroups.test.ts
+++ b/src/utils/ingredientSectionGroups.test.ts
@@ -4,7 +4,7 @@ import type { AggInput } from './ingredientAggregator';
 import { buildSectionGroups } from './ingredientSectionGroups';
 
 function section(name: string | null, ingredientIndices: number[]): SectionView {
-    return { name, steps: [], notes: [], ingredientIndices };
+    return { name, entries: [], ingredientIndices };
 }
 
 // index -> AggInput (or null for an ingredient that should not be listed)

--- a/src/utils/sectionHelpers.test.ts
+++ b/src/utils/sectionHelpers.test.ts
@@ -11,6 +11,7 @@ function makeRecipe() {
             {
                 name: 'Curry paste',
                 content: [
+                    { type: 'text', value: 'Prep everything before starting.' },
                     { type: 'step', value: { number: 1, items: [
                         { type: 'text', value: 'Blitz the ' },
                         { type: 'ingredient', index: 0 },
@@ -19,6 +20,10 @@ function makeRecipe() {
                         { type: 'text', value: '.' },
                     ] } },
                     { type: 'text', value: 'Make double and freeze.' },
+                    { type: 'step', value: { number: 2, items: [
+                        { type: 'text', value: 'Set aside.' },
+                    ] } },
+                    { type: 'text', value: 'Keep it warm.' },
                 ],
             },
             {
@@ -44,23 +49,35 @@ describe('getSections', () => {
 
     it('assigns a global 0-based step index across sections', () => {
         const s = getSections(makeRecipe());
-        expect(s[0].steps[0].globalIndex).toBe(0);
-        expect(s[1].steps[0].globalIndex).toBe(1);
+        expect(s[0].entries[1]).toMatchObject({ type: 'step', step: { globalIndex: 0 } });
+        expect(s[0].entries[3]).toMatchObject({ type: 'step', step: { globalIndex: 1 } });
+        expect(s[1].entries[0]).toMatchObject({ type: 'step', step: { globalIndex: 2 } });
     });
 
     it('resolves step parts to ingredient/cookware/timer objects', () => {
         const s = getSections(makeRecipe());
-        const parts = s[0].steps[0].parts;
+        const entry = s[0].entries[1];
+        expect(entry.type).toBe('step');
+        if (entry.type !== 'step') throw new Error('Expected a step entry');
+        const parts = entry.step.parts;
         expect(parts[0]).toEqual({ type: 'text', value: 'Blitz the ' });
         expect(parts[1]).toEqual({ type: 'ingredient', ingredient: { name: 'paste' } });
         expect(parts[3]).toEqual({ type: 'cookware', cookware: { name: 'blender' } });
-        expect(s[1].steps[0].parts[1]).toEqual({ type: 'timer', timer: { name: null } });
+        const timerEntry = s[1].entries[0];
+        expect(timerEntry.type).toBe('step');
+        if (timerEntry.type !== 'step') throw new Error('Expected a step entry');
+        expect(timerEntry.step.parts[1]).toEqual({ type: 'timer', timer: { name: null } });
     });
 
-    it('collects text blocks as notes', () => {
+    it('preserves notes before, between, and after steps', () => {
         const s = getSections(makeRecipe());
-        expect(s[0].notes).toEqual(['Make double and freeze.']);
-        expect(s[1].notes).toEqual([]);
+        expect(s[0].entries.map(entry => entry.type === 'step' ? 'step' : entry.note)).toEqual([
+            'Prep everything before starting.',
+            'step',
+            'Make double and freeze.',
+            'step',
+            'Keep it warm.',
+        ]);
     });
 
     it('collects unique ingredient indices per section in first-seen order', () => {

--- a/src/utils/sectionHelpers.ts
+++ b/src/utils/sectionHelpers.ts
@@ -2,7 +2,7 @@
  * Section view-model helpers.
  *
  * Reads recipe.sections into a structure the renderers can consume directly,
- * preserving section names, ordering text blocks as notes, and assigning each
+ * preserving section names and content order, and assigning each
  * step a global 0-based index (used for per-step images and current-step
  * tracking). Pure — imports types only, no WASM/Obsidian runtime.
  */
@@ -27,10 +27,14 @@ export interface StepView {
     parts: StepPart[];
 }
 
+export type SectionEntry =
+    | { type: 'step'; step: StepView }
+    | { type: 'note'; note: string };
+
 export interface SectionView {
     name: string | null;
-    steps: StepView[];
-    notes: string[];
+    /** Steps and notes in the order they appear in the Cooklang source. */
+    entries: SectionEntry[];
     /** Unique ingredient indices referenced in this section, first-seen order. */
     ingredientIndices: number[];
 }
@@ -42,15 +46,14 @@ export function getSections(recipe: CooklangRecipe): SectionView[] {
     for (const section of recipe.sections) {
         const view: SectionView = {
             name: section.name ?? null,
-            steps: [],
-            notes: [],
+            entries: [],
             ingredientIndices: [],
         };
         const seen = new Set<number>();
 
         for (const content of section.content) {
             if (content.type === 'text') {
-                view.notes.push(content.value);
+                view.entries.push({ type: 'note', note: content.value });
                 continue;
             }
             // content.type === 'step'
@@ -73,7 +76,10 @@ export function getSections(recipe: CooklangRecipe): SectionView[] {
                 }
                 // 'inlineQuantity' items are ignored in the preview
             }
-            view.steps.push({ number: step.number, globalIndex: globalIndex++, parts });
+            view.entries.push({
+                type: 'step',
+                step: { number: step.number, globalIndex: globalIndex++, parts },
+            });
         }
         result.push(view);
     }


### PR DESCRIPTION
## Overview

Cooklang text blocks are contextual notes, but the preview previously collected every note and rendered the entire group after a section’s method steps. That differs from the Cooklang CLI and removes the author-defined placement of notes.

This change keeps steps and notes together in the section view model, then renders each entry in source order. Notes now appear before, between, or after steps exactly where they occur in the recipe.

## Related Issue

None provided.

## Changes

- Preserve mixed step and note entries in their Cooklang source order.
- Render note callouts inline alongside method steps.
- Keep global step indexing intact for image and current-step tracking.
- Add test coverage for notes before, between, and after steps.
- Update dependent section-group test fixtures.

## Impact Scope

Affects recipe method rendering in the Obsidian preview. Ingredient grouping and existing step rendering behavior are unchanged.

## Checklist

- [x] Code follows the style guidelines
- [x] Tests have been added/updated
- [ ] Documentation has been updated (not relevant)
- [x] Build is successful
- [x] Ready for review

## How to Test

- Run `npm test` (52 tests passing).
- Run `npm run build` (passes; existing Rollup missing-export warnings remain).
- Open a recipe containing notes before, between, and after method steps in Obsidian and confirm each note appears in the corresponding source position.

## Additional Information

n/a