### PR TITLE
fix: stop note syntax highlighting at line end

### DIFF
--- a/src/mode/cook/cook.test.ts
+++ b/src/mode/cook/cook.test.ts
@@ -1,0 +1,54 @@
+import { EditorState } from '@codemirror/state';
+import { ensureSyntaxTree } from '@codemirror/language';
+import { classHighlighter, highlightTree } from '@lezer/highlight';
+import { describe, expect, it } from 'vitest';
+
+import { cooklang } from './cook';
+
+type HighlightRange = {
+    from: number;
+    to: number;
+    classes: string;
+};
+
+function highlightedRanges(doc: string): HighlightRange[] {
+    const state = EditorState.create({ doc, extensions: [cooklang] });
+    const tree = ensureSyntaxTree(state, doc.length, 1_000);
+
+    expect(tree).not.toBeNull();
+
+    const ranges: HighlightRange[] = [];
+    highlightTree(tree!, classHighlighter, (from, to, classes) => {
+        ranges.push({ from, to, classes });
+    });
+    return ranges;
+}
+
+describe('Cooklang syntax highlighting', () => {
+    it('ends note highlighting at the end of the line', () => {
+        const doc = [
+            '> Recommendation: 280 g per portion.',
+            '',
+            'Shape the dough in a #dough_box.',
+            'Dust with @semolina and rest for ~hours.',
+        ].join('\n');
+        const ranges = highlightedRanges(doc);
+
+        const noteEnd = doc.indexOf('\n');
+        const noteRanges = ranges.filter(({ from }) => from < noteEnd);
+        const rangesAfterNote = ranges.filter(({ from }) => from > noteEnd);
+
+        expect(noteRanges).toHaveLength(1);
+        expect(noteRanges[0]).toMatchObject({
+            from: 0,
+            to: noteEnd,
+            classes: 'tok-comment',
+        });
+        expect(rangesAfterNote.some(({ classes }) => classes.includes('tok-comment'))).toBe(false);
+        expect(rangesAfterNote.map(({ classes }) => classes)).toEqual([
+            'tok-keyword',
+            'tok-variableName',
+            'tok-number',
+        ]);
+    });
+});

--- a/src/mode/cook/cook.ts
+++ b/src/mode/cook/cook.ts
@@ -13,7 +13,6 @@ export const cooklang = StreamLanguage.define({
       position: null as string | null,
       inFrontmatter: false,  // Track if we're in frontmatter
       inMetadata: false,     // Track if we're in metadata section
-      inNote: false,         // Track if we're in a note
       inComment: false       // Track if we're in a comment
     };
   },
@@ -99,11 +98,6 @@ export const cooklang = StreamLanguage.define({
 
     // Check for notes (lines starting with >)
     if (sol && stream.match(/^>/)) {
-      state.inNote = true;
-      return "comment";
-    }
-
-    if (state.inNote) {
       stream.skipToEnd();
       return "comment";
     }


### PR DESCRIPTION
## Summary

- stop Cooklang note highlighting at the end of the note line
- remove the persistent `inNote` tokenizer state that styled all following lines as comments
- add a regression test covering cookware, ingredient, and timer highlighting after a note

## Verification

- `npm test` (53 tests passed)
- `npm run build`