### PR TITLE
fix: restore build after SectionView entries migration

### DIFF
--- a/src/utils/sectionHelpers.test.ts
+++ b/src/utils/sectionHelpers.test.ts
@@ -82,11 +82,14 @@ describe('getSections', () => {
 
     it('removes a repeated note marker after a backslash-created newline', () => {
         const recipe = makeRecipe();
-        recipe.sections[0].content[1].value = 'First line\n> second line';
+        recipe.sections[0].content[2].value = 'First line\n> second line';
 
         const s = getSections(recipe);
 
-        expect(s[0].notes).toEqual(['First line\nsecond line']);
+        expect(s[0].entries[2]).toEqual({
+            type: 'note',
+            note: 'First line\nsecond line',
+        });
     });
 
     it('collects unique ingredient indices per section in first-seen order', () => {


### PR DESCRIPTION
## Summary

- update the newline-normalization test to mutate the note entry rather than a step
- assert against the ordered `SectionView.entries` API introduced in 0.9.0

## Root cause

The ordered section-content change replaced `SectionView.steps` and `SectionView.notes` with `SectionView.entries`. A concurrently added regression test retained the old `.notes` assertion after the branches were merged. It also targeted content index 1, which became a step after the ordered-content test fixture was expanded.

Because Rollup's TypeScript plugin type-checks the test files, the stale `.notes` access prevented the 0.9.0 production build from completing.

## Impact

The production build succeeds again while the regression test continues to verify that repeated note markers are removed after backslash-created newlines.

## Validation

- `npm test` — 57 tests passed
- `npm run build` — production bundle completed
- `git diff --check`
