### PR TITLE
fix: restore TypeScript build after SectionView migration

### DIFF
--- a/src/utils/sectionHelpers.test.ts
+++ b/src/utils/sectionHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getSections } from './sectionHelpers';
+import { getSections, normalizeNoteText } from './sectionHelpers';
 
 // Minimal recipe shaped like CooklangRecipe (only fields getSections reads)
 function makeRecipe() {
@@ -81,15 +81,8 @@ describe('getSections', () => {
     });
 
     it('removes a repeated note marker after a backslash-created newline', () => {
-        const recipe = makeRecipe();
-        recipe.sections[0].content[2].value = 'First line\n> second line';
-
-        const s = getSections(recipe);
-
-        expect(s[0].entries[2]).toEqual({
-            type: 'note',
-            note: 'First line\nsecond line',
-        });
+        expect(normalizeNoteText('First line\n> second line'))
+            .toBe('First line\nsecond line');
     });
 
     it('collects unique ingredient indices per section in first-seen order', () => {


### PR DESCRIPTION
## Summary

- make the note-normalization regression test independent of the section fixture's content indexes
- record the build fix with a Conventional Commit that release-please can recognize

## Why this follow-up is needed

PR #95 fixed the 0.9.0 TypeScript build, but its commit was named `fix 0.9.0 TypeScript build` without the required colon after `fix`. Release-please therefore rejected that commit and GitHub's merge commit as non-conventional, leaving no commit from which to create the 0.9.1 release PR.

The merged history cannot be safely rewritten. This follow-up retains the regression coverage as a direct unit test of `normalizeNoteText`, and its `fix:` commit allows release-please to produce the intended patch release after merge.

## Validation

- `npm test` — 57 tests passed
- `npm run build` — production bundle completed
- `git diff --check`
