### PR TITLE
fix: specify repository for release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           TAG: ${{ steps.release.outputs.tag_name }}
           REPO: ${{ github.event.repository.name }}
         run: |
-          gh release upload "$TAG" \
+          gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" \
             main.js \
             manifest.json \
             styles.css \


### PR DESCRIPTION
## Summary

- pass the Actions-provided repository explicitly to `gh release upload`
- keep the existing `GH_TOKEN` authentication and artifact-directory workflow unchanged

## Why

The upload runs with `working-directory: release-files`, which is not a Git checkout. Without `--repo`, GitHub CLI tries to infer the repository from Git and fails with `fatal: not a git repository`.

Failed run: https://github.com/cooklang/cooklang-obsidian/actions/runs/30795471993

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/test.yml`
- `npm test` (57 tests)
- `npm run build`