### PR TITLE
fix: render inline quantities in recipe steps

### DIFF
--- a/src/renderers/MethodStepsRenderer.ts
+++ b/src/renderers/MethodStepsRenderer.ts
@@ -129,6 +129,9 @@ export class MethodStepsRenderer {
             if (this.settings.highlightIngredientCookware) span.addClass('cook-cw-hl');
         } else if (part.type === 'timer') {
             this.renderTimer(span, part.timer, unitMap);
+        } else if (part.type === 'inlineQuantity') {
+            span.addClass('cook-amt');
+            span.appendText(quantity_display(part.quantity));
         }
     }
 

--- a/src/utils/sectionHelpers.test.ts
+++ b/src/utils/sectionHelpers.test.ts
@@ -7,6 +7,11 @@ function makeRecipe() {
         ingredients: [{ name: 'paste' }, { name: 'coconut milk' }],
         cookware: [{ name: 'blender' }],
         timers: [{ name: null }],
+        inlineQuantities: [{
+            value: { type: 'number', value: { type: 'regular', value: 60 } },
+            unit: 'ml',
+            scalable: false,
+        }],
         sections: [
             {
                 name: 'Curry paste',
@@ -22,6 +27,7 @@ function makeRecipe() {
                     { type: 'text', value: 'Make double and freeze.' },
                     { type: 'step', value: { number: 2, items: [
                         { type: 'text', value: 'Set aside.' },
+                        { type: 'inlineQuantity', index: 0 },
                     ] } },
                     { type: 'text', value: 'Keep it warm.' },
                 ],
@@ -63,6 +69,13 @@ describe('getSections', () => {
         expect(parts[0]).toEqual({ type: 'text', value: 'Blitz the ' });
         expect(parts[1]).toEqual({ type: 'ingredient', ingredient: { name: 'paste' } });
         expect(parts[3]).toEqual({ type: 'cookware', cookware: { name: 'blender' } });
+        const inlineQuantityEntry = s[0].entries[3];
+        expect(inlineQuantityEntry.type).toBe('step');
+        if (inlineQuantityEntry.type !== 'step') throw new Error('Expected a step entry');
+        expect(inlineQuantityEntry.step.parts[1]).toEqual({
+            type: 'inlineQuantity',
+            quantity: makeRecipe().inlineQuantities[0],
+        });
         const timerEntry = s[1].entries[0];
         expect(timerEntry.type).toBe('step');
         if (timerEntry.type !== 'step') throw new Error('Expected a step entry');

--- a/src/utils/sectionHelpers.ts
+++ b/src/utils/sectionHelpers.ts
@@ -11,13 +11,15 @@ import type {
     Ingredient,
     Cookware,
     Timer,
+    Quantity,
 } from '@cooklang/cooklang';
 
 export type StepPart =
     | { type: 'text'; value: string }
     | { type: 'ingredient'; ingredient: Ingredient }
     | { type: 'cookware'; cookware: Cookware }
-    | { type: 'timer'; timer: Timer };
+    | { type: 'timer'; timer: Timer }
+    | { type: 'inlineQuantity'; quantity: Quantity };
 
 export interface StepView {
     /** Step number within its section (1-based, from parser). */
@@ -82,8 +84,12 @@ export function getSections(recipe: CooklangRecipe): SectionView[] {
                     parts.push({ type: 'cookware', cookware: recipe.cookware[item.index] });
                 } else if (item.type === 'timer') {
                     parts.push({ type: 'timer', timer: recipe.timers[item.index] });
+                } else if (item.type === 'inlineQuantity') {
+                    parts.push({
+                        type: 'inlineQuantity',
+                        quantity: recipe.inlineQuantities[item.index],
+                    });
                 }
-                // 'inlineQuantity' items are ignored in the preview
             }
             view.entries.push({
                 type: 'step',


### PR DESCRIPTION
## Summary

- preserve parsed `inlineQuantity` items in the preview step view model
- render standalone quantities and temperatures with Cooklang's quantity formatter
- add regression coverage for inline quantities in method steps

## Root cause

Cooklang parses standalone amounts and temperatures as `inlineQuantity` step items. The preview's section conversion explicitly ignored those items, so they were omitted from the rendered HTML entirely.

This keeps inline quantities as first-class step parts and renders them with the existing `cook-amt` styling.

## Validation

- `npm test` — 57 tests passed
- `npm run build` — production build succeeded

Fixes #88
