### PR TITLE
feat: aggregate ingredient units with Math.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^24.13.3",
         "howler": "^2.2.4",
         "jsdom": "^30.0.1",
+        "mathjs": "^15.2.0",
         "obsidian": "1.13.1",
         "rollup": "^4.62.4",
         "rollup-plugin-svelte": "^7.2.3",
@@ -1962,6 +1963,20 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
+    "node_modules/complex.js": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+      "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2092,6 +2107,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2162,6 +2184,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
@@ -2295,6 +2331,13 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2677,6 +2720,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdn-data": {
@@ -3140,6 +3207,13 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3307,6 +3381,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3416,6 +3497,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^24.13.3",
     "howler": "^2.2.4",
     "jsdom": "^30.0.1",
+    "mathjs": "^15.2.0",
     "obsidian": "1.13.1",
     "rollup": "^4.62.4",
     "rollup-plugin-svelte": "^7.2.3",

--- a/src/utils/ingredientAggregator.test.ts
+++ b/src/utils/ingredientAggregator.test.ts
@@ -31,8 +31,39 @@ describe('aggregateIngredients', () => {
         const rows = aggregateIngredients([
             ing({ name: 'egg yolks', quantityValue: 7, unit: null }),
             ing({ name: 'egg yolks', quantityValue: 4, unit: 'large' }),
+            ing({ name: 'dressing', quantityValue: 100, unit: 'g' }),
+            ing({ name: 'dressing', quantityValue: 25, unit: 'ml' }),
         ]);
         expect(rows[0].displayQty).toBe('7 + 4 large');
+        expect(rows[1].displayQty).toBe('100 g + 25 ml');
+    });
+
+    it('combines grams and kilograms using the largest denomination present', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'pizza flour', quantityValue: 150, unit: 'g' }),
+            ing({ name: 'pizza flour', quantityValue: 1.35, unit: 'kg' }),
+        ]);
+        expect(rows[0].displayQty).toBe('1.5 kg');
+
+        const reversed = aggregateIngredients([
+            ing({ name: 'pizza flour', quantityValue: 1.35, unit: 'kilograms' }),
+            ing({ name: 'pizza flour', quantityValue: 150, unit: 'grams' }),
+        ]);
+        expect(reversed[0].displayQty).toBe('1.5 kilograms');
+    });
+
+    it('uses Math.js to combine compatible units and select the best display unit', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'stock', quantityValue: 750, unit: 'ml' }),
+            ing({ name: 'stock', quantityValue: 0.5, unit: 'l' }),
+            ing({ name: 'butter', quantityValue: 1, unit: 'lb' }),
+            ing({ name: 'butter', quantityValue: 8, unit: 'oz' }),
+            ing({ name: 'vanilla', quantityValue: 1, unit: 'tbsp' }),
+            ing({ name: 'vanilla', quantityValue: 3, unit: 'tsp' }),
+        ]);
+        expect(rows[0].displayQty).toBe('1.25 l');
+        expect(rows[1].displayQty).toBe('1.5 lb');
+        expect(rows[2].displayQty).toBe('2 tbsp');
     });
 
     it('lists range/textual amounts as-is', () => {

--- a/src/utils/ingredientAggregator.ts
+++ b/src/utils/ingredientAggregator.ts
@@ -4,9 +4,19 @@
  * The parser's group_ingredients only merges *references* into their definition;
  * it leaves separate same-name definitions apart (e.g. `@flour{5%cups}` written
  * twice = two entries). This merges rows by display name and sums quantities
- * that share a unit. Different units are shown side by side ("5 cups + 2 tbsp");
- * ranges / textual amounts are listed as-is. No cross-unit conversion.
+ * that share a compatible Math.js unit. The total is rendered with Math.js's
+ * best-fitting unit ("150 g + 1.35 kg" becomes "1.5 kg"). Unrecognized or
+ * incompatible units are shown side by side; ranges / textual amounts are
+ * listed as-is.
  */
+
+import {
+    addDependencies,
+    create,
+    createUnitDependencies,
+    unitDependencies,
+    type Unit,
+} from 'mathjs';
 
 export interface RecipeRefTarget {
     /** Display name of the referenced recipe (e.g. "Beans"). */
@@ -41,17 +51,39 @@ export function formatQuantity(n: number): string {
     return String(Math.round(n * 100) / 100);
 }
 
-/** Group key that treats "cup"/"cups" as the same unit. */
-function unitKey(unit: string | null): string {
+const unitMath = create({ addDependencies, createUnitDependencies, unitDependencies });
+unitMath.createUnit('tbsp', { definition: '1 tablespoon', aliases: ['tbs'] });
+unitMath.createUnit('tsp', '1 teaspoon');
+
+type QuantityBucket =
+    | { type: 'unit'; total: Unit }
+    | { type: 'raw'; key: string; sum: number; unitDisplay: string };
+
+const MATHJS_UNIT_ALIASES: Record<string, string> = {
+    'fl oz': 'floz',
+    'fl. oz.': 'floz',
+};
+
+/** Normalizes plural labels so "cup" and "cups" share a bucket. */
+function normalizeUnit(unit: string | null): string {
     return (unit ?? '').trim().toLowerCase().replace(/s$/, '');
+}
+
+function parsedUnit(value: number, unit: string | null): Unit | null {
+    if (!unit?.trim()) return null;
+    try {
+        const normalized = unit.trim().toLowerCase();
+        return unitMath.unit(value, MATHJS_UNIT_ALIASES[normalized] ?? unit);
+    } catch {
+        return null;
+    }
 }
 
 export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
     const order: string[] = [];
     const groups = new Map<string, {
         name: string;
-        units: Map<string, { sum: number; unitDisplay: string }>;
-        unitOrder: string[];
+        quantities: QuantityBucket[];
         textParts: string[];
         note: string | null;
         reference: RecipeRefTarget | null;
@@ -62,8 +94,7 @@ export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
         if (!group) {
             group = {
                 name: item.name,
-                units: new Map(),
-                unitOrder: [],
+                quantities: [],
                 textParts: [],
                 note: null,
                 reference: null,
@@ -73,14 +104,34 @@ export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
         }
 
         if (item.quantityValue !== null) {
-            const key = unitKey(item.unit);
-            let bucket = group.units.get(key);
-            if (!bucket) {
-                bucket = { sum: 0, unitDisplay: item.unit ?? '' };
-                group.units.set(key, bucket);
-                group.unitOrder.push(key);
+            const quantity = parsedUnit(item.quantityValue, item.unit);
+            if (quantity) {
+                const bucket = group.quantities.find(
+                    (candidate): candidate is Extract<QuantityBucket, { type: 'unit' }> =>
+                        candidate.type === 'unit' && candidate.total.equalBase(quantity),
+                );
+                if (bucket) {
+                    bucket.total = unitMath.add(bucket.total, quantity) as Unit;
+                } else {
+                    group.quantities.push({ type: 'unit', total: quantity });
+                }
+            } else {
+                const key = normalizeUnit(item.unit);
+                const bucket = group.quantities.find(
+                    (candidate): candidate is Extract<QuantityBucket, { type: 'raw' }> =>
+                        candidate.type === 'raw' && candidate.key === key,
+                );
+                if (bucket) {
+                    bucket.sum += item.quantityValue;
+                } else {
+                    group.quantities.push({
+                        type: 'raw',
+                        key,
+                        sum: item.quantityValue,
+                        unitDisplay: item.unit ?? '',
+                    });
+                }
             }
-            bucket.sum += item.quantityValue;
         } else if (item.quantityText) {
             group.textParts.push(item.quantityText);
         }
@@ -91,13 +142,11 @@ export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
 
     return order.map(name => {
         const group = groups.get(name)!;
-        const parts: string[] = [];
-        for (const key of group.unitOrder) {
-            const bucket = group.units.get(key)!;
-            parts.push(bucket.unitDisplay
+        const parts = group.quantities.map(bucket => bucket.type === 'unit'
+            ? bucket.total.toBest().format({ precision: 3 })
+            : bucket.unitDisplay
                 ? `${formatQuantity(bucket.sum)} ${bucket.unitDisplay}`
                 : formatQuantity(bucket.sum));
-        }
         parts.push(...group.textParts);
         return {
             name: group.name,


### PR DESCRIPTION
## Summary

- add Math.js through its custom dependency factories instead of importing the full `all` bundle
- aggregate same-name ingredient quantities by compatible physical dimension
- use `Unit.toBest()` to choose a readable output unit after addition
- preserve separate output for incompatible dimensions and unknown Cooklang-specific units
- register common cooking aliases for `tbsp`, `tbs`, and `tsp`, plus fluid-ounce spellings

## Why

Ingredient aggregation previously grouped exact unit labels only, so compatible quantities such as `150 g` and `1.35 kg` were displayed as `150 g + 1.35 kg`. The implementation now delegates conversion and best-unit selection to Math.js rather than maintaining a local conversion table.

## Impact

Examples include:

- `150 g + 1.35 kg` → `1.5 kg`
- `1 lb + 8 oz` → `1.5 lb`
- `1 tbsp + 3 tsp` → `2 tbsp`

Unknown units retain the existing fallback behavior, while recognized but incompatible units remain separate.

Math.js has a meaningful bundle cost even with custom factories: the production `main.js` grows from approximately 5.04 MB to 6.73 MB raw, or 1.453 MB to 1.735 MB with gzip. This tradeoff is included explicitly for review.

## Validation

- `npm run typecheck`
- `npm test` — 12 files, 60 tests
- `npm run build`
