### PR TITLE
fix: contain wrapped text within recipe pills

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -231,14 +231,15 @@
 .cook-pills { display: flex; flex-wrap: wrap; gap: var(--size-2-2, 6px); }
 .cook-pill {
   display: inline-flex; align-items: center; gap: 5px;
-  height: 26px; padding: 0 11px;
+  box-sizing: border-box; min-width: 0; max-width: 100%; min-height: 26px; padding: 2px 11px;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 13px; font-size: 0.8em; color: var(--text-muted);
+  border-radius: 999px; font-size: 0.8em; line-height: 1.3; color: var(--text-muted);
+  overflow-wrap: anywhere;
   text-decoration: none;
 }
 a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent); }
-.cook-pill-icon { opacity: 0.85; }
+.cook-pill-icon { flex: 0 0 auto; opacity: 0.85; }
 .cook-pill-tag { background: transparent; border-color: var(--text-accent); color: var(--text-accent); }
 
 /* Sticky bar */


### PR DESCRIPTION
## Summary

- allow recipe metadata pills to expand vertically when their text wraps
- constrain long pill content to the available width and allow URLs to break safely
- keep pill icons from shrinking while preserving the lozenge border shape

## Problem

Recipe metadata pills used a fixed 26px height even though their text could wrap. In narrow panes, a long source URL could flow onto a second line outside the pill border.

## User impact

Wrapped metadata and source links now remain fully contained within their lozenge borders across narrow layouts.

## Validation

- `npm test` (16 files, 82 tests passed)
- `npm run build`
