### PR TITLE
fix: suppress Math.js dependency cycle warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,20 +55,27 @@ function markdownString() {
   };
 }
 
-function isSvelteCircularDependency(warning) {
+function isKnownDependencyCycle(warning) {
   if (warning.code !== 'CIRCULAR_DEPENDENCY' || !warning.ids?.length) {
     return false;
   }
 
-  return warning.ids.every(id =>
-    id.replaceAll('\\', '/').includes('/node_modules/svelte/')
+  const dependencyPaths = [
+    '/node_modules/mathjs/',
+    '/node_modules/svelte/'
+  ];
+
+  return dependencyPaths.some(dependencyPath =>
+    warning.ids.every(id =>
+      id.replaceAll('\\', '/').includes(dependencyPath)
+    )
   );
 }
 
 export default {
   input: 'src/main.ts',
   onwarn(warning, warn) {
-    if (!isSvelteCircularDependency(warning)) {
+    if (!isKnownDependencyCycle(warning)) {
       warn(warning);
     }
   },


### PR DESCRIPTION
## Summary

- generalize the existing Rollup circular-dependency filter for known third-party cycles
- ignore Math.js cycles only when every module in the cycle is inside `node_modules/mathjs`
- preserve warnings for application cycles and cycles crossing package boundaries

## Why

Math.js 15.2.0 contains internal ESM utility cycles that Rollup reports while bundling the ingredient aggregation feature. These cycles are internal to the dependency and do not involve plugin code, so the warning is not actionable in this repository.

This keeps production-build output clean without masking newly introduced circular dependencies in the plugin.

## Validation

- `npm test` — 82 tests passed on `upstream/main`
- `npm run build -- --preserveSymlinks` — passed in the isolated worktree with no circular-dependency warning
- `npm run build` — passed in the primary checkout with no circular-dependency warning
- `git diff --check` — passed
