### PR TITLE
feat: add interactive timer range controls

### DIFF
--- a/src/services/TimerService.test.ts
+++ b/src/services/TimerService.test.ts
@@ -27,7 +27,7 @@ describe('TimerService timer controller', () => {
             { timersTick: false, timersRing: false } as any,
             { tickSoundUrl: 'tick.mp3', alarmSoundUrl: 'alarm.mp3' },
         );
-        const snapshots: TimerSnapshot[] = [];
+        const snapshots: Array<TimerSnapshot | null> = [];
         const unsubscribe = service.subscribe('step-1-timer-1', snapshot => {
             snapshots.push(snapshot);
         });
@@ -70,6 +70,27 @@ describe('TimerService timer controller', () => {
         service.toggle('timer', 1, 'rest');
         expect(service.getSnapshot('timer')).toMatchObject({ remaining: 1, status: 'running' });
         expect(service.getAllTimers()).toHaveLength(2);
+
+        service.dispose();
+    });
+
+    it('cancels and forgets a keyed timer so a new duration can be selected', () => {
+        const service = new TimerService(
+            { timersTick: false, timersRing: false } as any,
+            { tickSoundUrl: 'tick.mp3', alarmSoundUrl: 'alarm.mp3' },
+        );
+        const snapshots: Array<TimerSnapshot | null> = [];
+        service.subscribe('timer', snapshot => snapshots.push(snapshot));
+
+        service.toggle('timer', 120, 'rest');
+        service.reset('timer');
+
+        expect(service.getSnapshot('timer')).toBeNull();
+        expect(service.getAllTimers()).toHaveLength(0);
+        expect(snapshots[snapshots.length - 1]).toBeNull();
+
+        service.toggle('timer', 180, 'rest');
+        expect(service.getSnapshot('timer')).toMatchObject({ duration: 180, status: 'running' });
 
         service.dispose();
     });

--- a/src/services/TimerService.ts
+++ b/src/services/TimerService.ts
@@ -49,7 +49,7 @@ export class TimerService {
     private timers: Map<string, Timer> = new Map();
     private timerIdsByKey: Map<string, string> = new Map();
     private keysByTimerId: Map<string, string> = new Map();
-    private listeners: Map<string, Set<(snapshot: TimerSnapshot) => void>> = new Map();
+    private listeners: Map<string, Set<(snapshot: TimerSnapshot | null) => void>> = new Map();
     private tickSound: Howl;
     private alarmSound: Howl;
 
@@ -84,7 +84,7 @@ export class TimerService {
         this.startTimer(seconds, label, undefined, key);
     }
 
-    public subscribe(key: string, listener: (snapshot: TimerSnapshot) => void): () => void {
+    public subscribe(key: string, listener: (snapshot: TimerSnapshot | null) => void): () => void {
         let listeners = this.listeners.get(key);
         if (!listeners) {
             listeners = new Set();
@@ -101,6 +101,19 @@ export class TimerService {
             current?.delete(listener);
             if (current?.size === 0) this.listeners.delete(key);
         };
+    }
+
+    /** Cancel and forget the timer assigned to a rendered timer control. */
+    public reset(key: string): void {
+        const timerId = this.timerIdsByKey.get(key);
+        const timer = timerId ? this.timers.get(timerId) : undefined;
+        if (!timerId) return;
+
+        if (timer?.intervalId !== undefined) clearInterval(timer.intervalId);
+        this.timers.delete(timerId);
+        this.timerIdsByKey.delete(key);
+        this.keysByTimerId.delete(timerId);
+        for (const listener of this.listeners.get(key) ?? []) listener(null);
     }
 
     /**

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -373,10 +373,83 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-cw-hl { color: var(--color-orange, var(--text-accent)); font-weight: 600; }
 .cook-amt { color: var(--text-muted); }
 .cook-timer-btn {
-  background: transparent; border: 1px solid var(--text-accent); color: var(--text-accent);
-  border-radius: 13px; min-height: 26px; padding: 1px 8px; font-size: 0.9em; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 0.25em;
+  min-width: 0; min-height: 22px; padding: 0; border: 0;
+  appearance: none; background: transparent !important; box-shadow: none !important;
+  color: inherit; cursor: pointer; font: inherit;
 }
 .cook-timer-name { margin-inline-start: 0.25em; }
+.cook-timer-range-anchor {
+  position: relative; display: inline-block; vertical-align: middle;
+}
+.cook-timer-chip {
+  display: inline-flex; align-items: center; gap: 0.25em;
+  box-sizing: border-box; min-height: 26px; padding: 1px 8px;
+  background: var(--background-secondary); border: 1px solid var(--text-accent); color: var(--text-accent);
+  border-radius: 13px; font-size: 0.9em;
+}
+.cook-timer-chip:hover { background: var(--background-modifier-hover); }
+.cook-timer-chip.cook-timer-running {
+  animation: cook-timer-border-pulse 1.6s ease-in-out infinite;
+}
+@keyframes cook-timer-border-pulse {
+  0%, 100% {
+    border-color: var(--text-accent);
+    color: var(--text-accent);
+    box-shadow: 0 0 0 0 transparent;
+  }
+  50% {
+    border-color: var(--color-green, var(--interactive-success, #4caf50));
+    color: var(--color-green, var(--interactive-success, #4caf50));
+    box-shadow: 0 0 0 2px var(--color-green, var(--interactive-success, #4caf50));
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cook-timer-chip.cook-timer-running {
+    animation: none;
+    border-color: var(--color-green, var(--interactive-success, #4caf50));
+    color: var(--color-green, var(--interactive-success, #4caf50));
+  }
+}
+.cook-timer-icon { display: inline-block; flex: 0 0 1em; width: 1em; text-align: center; }
+.cook-timer-reset-btn {
+  flex: 0 0 1em; width: 1em; height: 22px; padding: 0; border: 0; border-radius: 4px;
+  appearance: none; background: transparent !important; box-shadow: none !important;
+  color: inherit; cursor: pointer; font: inherit;
+}
+.cook-timer-chip .cook-timer-btn:hover,
+.cook-timer-chip .cook-timer-btn:active,
+.cook-timer-chip .cook-timer-btn:focus,
+.cook-timer-chip .cook-timer-reset-btn:hover,
+.cook-timer-chip .cook-timer-reset-btn:active,
+.cook-timer-chip .cook-timer-reset-btn:focus { background: transparent !important; box-shadow: none !important; }
+.cook-timer-range-popover {
+  position: absolute; z-index: var(--layer-popover, 1000); top: calc(100% + 6px);
+  width: min(280px, calc(100vw - 16px));
+  box-sizing: border-box; padding: var(--size-4-3, 12px);
+  background: var(--background-primary); color: var(--text-normal);
+  border: 1px solid var(--background-modifier-border); border-radius: var(--radius-m, 8px);
+  box-shadow: var(--shadow-s); opacity: 0; pointer-events: none;
+}
+.cook-timer-range-popover.cook-timer-range-ready { opacity: 1; pointer-events: auto; }
+.cook-timer-range-header {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--size-4-2, 8px);
+  margin-bottom: var(--size-4-2, 8px);
+}
+.cook-timer-range-value { font-weight: 600; font-variant-numeric: tabular-nums; }
+.cook-timer-range-close {
+  width: 28px; height: 28px; padding: 0; border: 0; border-radius: var(--radius-s, 4px);
+  background: transparent; color: var(--text-muted); cursor: pointer; font: inherit; font-size: 1.25em;
+}
+.cook-timer-range-close:hover { background: var(--background-modifier-hover); color: var(--text-normal); }
+.cook-timer-range-slider { display: block; width: 100%; margin: 0; accent-color: var(--interactive-accent); }
+.cook-timer-range-bounds {
+  display: flex; justify-content: space-between; margin-top: var(--size-2-1, 4px);
+  color: var(--text-muted); font-size: var(--font-ui-smaller); font-variant-numeric: tabular-nums;
+}
+.cook-timer-range-help {
+  display: block; margin-top: var(--size-4-2, 8px); color: var(--text-faint); font-size: var(--font-ui-smaller);
+}
 
 /* Notes */
 .cook-note {
@@ -431,6 +504,9 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-ing-checkbox:focus-visible,
 .cook-step-toggle:focus-visible,
 .cook-timer-btn:focus-visible,
+.cook-timer-reset-btn:focus-visible,
+.cook-timer-range-close:focus-visible,
+.cook-timer-range-slider:focus-visible,
 .cook-bar-link:focus-visible,
 .cook-ref-link:focus-visible {
   outline: 2px solid var(--interactive-accent);

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -129,6 +129,7 @@ function model(overrides: Partial<RecipeRenderModel> = {}): RecipeRenderModel {
     };
     const timers: TimerController = {
         toggle: vi.fn(),
+        reset: vi.fn(),
         subscribe: () => () => {},
     };
     return {
@@ -171,11 +172,8 @@ describe('RecipePreview', () => {
         expect(renderModel.callbacks.onStepActivate).toHaveBeenCalledWith(0);
 
         await fireEvent.click(screen.getByRole('button', { name: /Start rest/ }));
-        expect(renderModel.timers?.toggle).toHaveBeenCalledWith(
-            'test-recipe:step-0:part-5',
-            120,
-            'rest',
-        );
+        expect(screen.getByRole('dialog', { name: 'Choose duration for rest' })).toBeTruthy();
+        expect(renderModel.timers?.toggle).not.toHaveBeenCalled();
     });
 
     it('honors settings that hide optional recipe regions', () => {
@@ -222,11 +220,214 @@ describe('ReferenceLink', () => {
 });
 
 describe('TimerButton', () => {
+    it('starts a fixed-duration timer immediately', async () => {
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset: vi.fn(),
+            subscribe: () => () => {},
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 60 },
+            label: 'rest',
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Start rest (1:00)' }));
+        expect(controller.toggle).toHaveBeenCalledOnce();
+        expect(controller.toggle).toHaveBeenCalledWith('timer', 60, 'rest');
+    });
+
+    it('opens a range selector and starts the selected duration on pointer release', async () => {
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset: vi.fn(),
+            subscribe: () => () => {},
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 180 },
+            label: 'rest',
+        });
+
+        const button = screen.getByRole('button', { name: 'Start rest (1:00–3:00)' });
+        await fireEvent.click(button);
+
+        const dialog = screen.getByRole('dialog', { name: 'Choose duration for rest' });
+        const anchor = button.closest('.cook-timer-range-anchor');
+        expect(anchor).toBeTruthy();
+        expect(dialog.parentElement).toBe(anchor);
+        const slider = screen.getByRole('slider', { name: 'Duration for rest' });
+        expect(document.activeElement).toBe(slider);
+        expect(slider.getAttribute('min')).toBe('60');
+        expect(slider.getAttribute('max')).toBe('180');
+        expect(slider.getAttribute('step')).toBe('60');
+        expect((slider as HTMLInputElement).value).toBe('60');
+        expect(screen.getAllByText('1:00')).toHaveLength(2);
+        expect(screen.getByText('3:00')).toBeTruthy();
+        expect(controller.toggle).not.toHaveBeenCalled();
+
+        await fireEvent.input(slider, { target: { value: '120' } });
+        expect(slider.getAttribute('aria-valuetext')).toBe('2:00');
+        await fireEvent.pointerUp(slider);
+
+        expect(controller.toggle).toHaveBeenCalledOnce();
+        expect(controller.toggle).toHaveBeenCalledWith('timer', 120, 'rest');
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('uses second precision for a range with sub-minute bounds', async () => {
+        render(TimerButton, {
+            controller: { toggle: vi.fn(), reset: vi.fn(), subscribe: () => () => {} },
+            timerKey: 'timer',
+            duration: { minimumSeconds: 30, maximumSeconds: 90 },
+            label: '',
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Start timer (30s–1:30)' }));
+        expect(screen.getByRole('slider').getAttribute('step')).toBe('1');
+    });
+
+    it('pauses and resumes an existing range timer without opening the selector', async () => {
+        const listeners: Array<(snapshot: TimerSnapshot | null) => void> = [];
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset: vi.fn(),
+            subscribe: (_key, callback) => {
+                listeners.push(callback);
+                return () => {};
+            },
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 180 },
+            label: 'rest',
+        });
+
+        const listener = listeners[0];
+        if (!listener) throw new Error('Expected the timer component to subscribe.');
+        listener({ id: 'id', duration: 120, remaining: 90, label: 'rest', status: 'running' });
+        const runningButton = await screen.findByRole('button', { name: 'Pause rest (1:30)' });
+        expect(runningButton.parentElement?.classList.contains('cook-timer-running')).toBe(true);
+        await fireEvent.click(runningButton);
+        expect(screen.queryByRole('dialog')).toBeNull();
+
+        listener({ id: 'id', duration: 120, remaining: 90, label: 'rest', status: 'paused' });
+        const pausedButton = await screen.findByRole('button', { name: 'Resume rest (1:30)' });
+        expect(pausedButton.parentElement?.classList.contains('cook-timer-running')).toBe(false);
+        await fireEvent.click(pausedButton);
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(controller.toggle).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets an active timer and allows a new range duration to be selected', async () => {
+        const listeners: Array<(snapshot: TimerSnapshot | null) => void> = [];
+        const reset = vi.fn(() => {
+            for (const listener of listeners) listener(null);
+        });
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset,
+            subscribe: (_key, callback) => {
+                listeners.push(callback);
+                return () => {};
+            },
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 180 },
+            label: 'rest',
+        });
+
+        listeners[0]?.({ id: 'id', duration: 120, remaining: 90, label: 'rest', status: 'running' });
+        const activeTimer = await screen.findByRole('button', { name: 'Pause rest (1:30)' });
+        const resetButton = screen.getByRole('button', { name: 'Reset rest timer' });
+        expect(resetButton.parentElement).toBe(activeTimer.parentElement);
+        expect(activeTimer.parentElement?.classList.contains('cook-timer-chip')).toBe(true);
+        expect(activeTimer.querySelector('.cook-timer-icon')).toBeNull();
+        await fireEvent.click(resetButton);
+
+        expect(reset).toHaveBeenCalledWith('timer');
+        const timerButton = await screen.findByRole('button', { name: 'Start rest (1:00–3:00)' });
+        expect(screen.queryByRole('button', { name: 'Reset rest timer' })).toBeNull();
+
+        await fireEvent.click(timerButton);
+        const slider = screen.getByRole('slider');
+        await fireEvent.input(slider, { target: { value: '180' } });
+        await fireEvent.pointerUp(slider);
+        expect(controller.toggle).toHaveBeenCalledWith('timer', 180, 'rest');
+    });
+
+    it('reopens a completed range at its minimum', async () => {
+        const listeners: Array<(snapshot: TimerSnapshot | null) => void> = [];
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset: vi.fn(),
+            subscribe: (_key, callback) => {
+                listeners.push(callback);
+                return () => {};
+            },
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 180 },
+            label: 'rest',
+        });
+
+        listeners[0]?.({ id: 'id', duration: 120, remaining: 0, label: 'rest', status: 'completed' });
+        await fireEvent.click(await screen.findByRole('button', { name: 'Start rest (0s)' }));
+        expect((screen.getByRole('slider') as HTMLInputElement).value).toBe('60');
+        expect(controller.toggle).not.toHaveBeenCalled();
+    });
+
+    it('dismisses without starting and supports keyboard activation', async () => {
+        const controller: TimerController = {
+            toggle: vi.fn(),
+            reset: vi.fn(),
+            subscribe: () => () => {},
+        };
+        render(TimerButton, {
+            controller,
+            timerKey: 'timer',
+            duration: { minimumSeconds: 60, maximumSeconds: 180 },
+            label: 'rest',
+        });
+        const button = screen.getByRole('button', { name: 'Start rest (1:00–3:00)' });
+
+        await fireEvent.click(button);
+        await fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(document.activeElement).toBe(button);
+        expect(controller.toggle).not.toHaveBeenCalled();
+
+        await fireEvent.click(button);
+        await fireEvent.pointerDown(document.body);
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(controller.toggle).not.toHaveBeenCalled();
+
+        await fireEvent.click(button);
+        await fireEvent.click(screen.getByRole('button', { name: 'Close timer range selector' }));
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(controller.toggle).not.toHaveBeenCalled();
+
+        await fireEvent.click(button);
+        const slider = screen.getByRole('slider');
+        await fireEvent.input(slider, { target: { value: '180' } });
+        await fireEvent.keyDown(slider, { key: 'Enter' });
+        expect(controller.toggle).toHaveBeenCalledOnce();
+        expect(controller.toggle).toHaveBeenCalledWith('timer', 180, 'rest');
+    });
+
     it('reflects subscribed pause state and unsubscribes on unmount', async () => {
-        const listeners: Array<(snapshot: TimerSnapshot) => void> = [];
+        const listeners: Array<(snapshot: TimerSnapshot | null) => void> = [];
         const unsubscribe = vi.fn();
         const controller: TimerController = {
             toggle: vi.fn(),
+            reset: vi.fn(),
             subscribe: (_key, callback) => {
                 listeners.push(callback);
                 return unsubscribe;

--- a/src/ui/components/TimerButton.svelte
+++ b/src/ui/components/TimerButton.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
+    import { onMount, tick } from 'svelte';
     import type { TimerSnapshot } from '../../services/TimerService';
     import {
         formatTime,
         formatTimerDuration,
+        timerRangeStep,
         type TimerDuration,
     } from '../../utils/timeFormatters';
     import type { TimerController } from '../types';
@@ -21,29 +22,205 @@
     } = $props();
 
     let snapshot = $state<TimerSnapshot | null>(null);
+    let buttonElement = $state<HTMLButtonElement>();
+    let popoverElement = $state<HTMLSpanElement>();
+    let sliderElement = $state<HTMLInputElement>();
+    let selectorOpen = $state(false);
+    let selectorReady = $state(false);
+    let selectedSeconds = $state(0);
+    let popoverLeft = $state(0);
     let status = $derived(snapshot?.status ?? 'idle');
+    let isRange = $derived(duration.minimumSeconds !== duration.maximumSeconds);
+    let sliderStep = $derived(timerRangeStep(duration));
+    let sliderHelpId = $derived(`cook-timer-range-help-${timerKey.replace(/[^a-zA-Z0-9_-]/g, '-')}`);
     let displayTime = $derived(snapshot ? formatTime(snapshot.remaining) : formatTimerDuration(duration));
     let action = $derived(status === 'running' ? 'Pause' : status === 'paused' ? 'Resume' : 'Start');
     let accessibleLabel = $derived(`${action} ${label || 'timer'} (${displayTime})`);
 
-    onMount(() => controller.subscribe(timerKey, value => {
-        snapshot = value;
-    }));
+    onMount(() => {
+        const unsubscribe = controller.subscribe(timerKey, value => {
+            snapshot = value;
+        });
 
-    function toggle(event: MouseEvent): void {
+        function handleOutsidePointer(event: PointerEvent): void {
+            if (!selectorOpen || !(event.target instanceof Node)) return;
+            if (buttonElement?.contains(event.target) || popoverElement?.contains(event.target)) return;
+            closeSelector(false);
+        }
+
+        function handleKeydown(event: KeyboardEvent): void {
+            if (selectorOpen && event.key === 'Escape') {
+                event.preventDefault();
+                closeSelector(true);
+            }
+        }
+
+        function handleViewportChange(): void {
+            if (selectorOpen) positionPopover();
+        }
+
+        document.addEventListener('pointerdown', handleOutsidePointer, true);
+        document.addEventListener('keydown', handleKeydown);
+        window.addEventListener('resize', handleViewportChange);
+        window.addEventListener('scroll', handleViewportChange, true);
+
+        return () => {
+            unsubscribe();
+            document.removeEventListener('pointerdown', handleOutsidePointer, true);
+            document.removeEventListener('keydown', handleKeydown);
+            window.removeEventListener('resize', handleViewportChange);
+            window.removeEventListener('scroll', handleViewportChange, true);
+        };
+    });
+
+    function activate(event: MouseEvent): void {
         event.stopPropagation();
-        controller.toggle(timerKey, duration.minimumSeconds, label);
+
+        if (status === 'running' || status === 'paused' || !isRange) {
+            controller.toggle(timerKey, duration.minimumSeconds, label);
+            return;
+        }
+
+        openSelector();
     }
+
+    function openSelector(): void {
+        selectedSeconds = duration.minimumSeconds;
+        selectorReady = false;
+        selectorOpen = true;
+        void tick().then(() => {
+            if (!selectorOpen) return;
+            positionPopover();
+            selectorReady = true;
+            sliderElement?.focus();
+        });
+    }
+
+    function closeSelector(restoreFocus: boolean): void {
+        if (!selectorOpen) return;
+        selectorOpen = false;
+        selectorReady = false;
+        if (restoreFocus) void tick().then(() => buttonElement?.focus());
+    }
+
+    function positionPopover(): void {
+        if (!buttonElement || !popoverElement) return;
+
+        const margin = 8;
+        const buttonRect = buttonElement.getBoundingClientRect();
+        const popoverRect = popoverElement.getBoundingClientRect();
+        const pane = buttonElement.closest('.view-content, .workspace-leaf-content');
+        const paneRect = pane?.getBoundingClientRect();
+        const boundaryLeft = paneRect?.left ?? 0;
+        const boundaryRight = paneRect?.right ?? window.innerWidth;
+        const targetLeft = Math.min(
+            Math.max(buttonRect.left, boundaryLeft + margin),
+            Math.max(boundaryLeft + margin, boundaryRight - popoverRect.width - margin),
+        );
+        popoverLeft = targetLeft - buttonRect.left;
+    }
+
+    function updateSelection(event: Event): void {
+        selectedSeconds = Number((event.currentTarget as HTMLInputElement).value);
+    }
+
+    function startSelected(): void {
+        if (!selectorOpen) return;
+        const seconds = selectedSeconds;
+        closeSelector(true);
+        controller.toggle(timerKey, seconds, label);
+    }
+
+    function handleSliderKeydown(event: KeyboardEvent): void {
+        if (event.key !== 'Enter') return;
+        event.preventDefault();
+        startSelected();
+    }
+
+    function closeFromButton(event: MouseEvent): void {
+        event.stopPropagation();
+        closeSelector(true);
+    }
+
+    function resetTimer(event: MouseEvent): void {
+        event.stopPropagation();
+        closeSelector(false);
+        controller.reset(timerKey);
+        void tick().then(() => buttonElement?.focus());
+    }
+
 </script>
 
-<button
-    type="button"
-    class="cook-timer-btn"
-    aria-label={accessibleLabel}
-    aria-pressed={status === 'running'}
-    onclick={toggle}
->
-    <span aria-hidden="true">⏱</span>{' '}
-    <span class="cook-amt amount" aria-live="polite">{displayTime}</span>
-    {#if label}<span class="cook-timer-name">{label}</span>{/if}
-</button>
+<span class="cook-timer-range-anchor">
+    <span class="cook-timer-chip" class:cook-timer-running={status === 'running'}>
+        {#if status === 'running' || status === 'paused'}
+            <button
+                type="button"
+                class="cook-timer-reset-btn"
+                aria-label={`Reset ${label || 'timer'} timer`}
+                onclick={resetTimer}
+            >↺</button>
+        {/if}
+
+        <button
+            bind:this={buttonElement}
+            type="button"
+            class="cook-timer-btn"
+            aria-label={accessibleLabel}
+            aria-pressed={status === 'running'}
+            aria-haspopup={isRange ? 'dialog' : undefined}
+            aria-expanded={isRange ? selectorOpen : undefined}
+            onclick={activate}
+        >
+            {#if status !== 'running' && status !== 'paused'}
+                <span class="cook-timer-icon" aria-hidden="true">⏱</span>
+            {/if}
+            <span class="cook-amt amount" aria-live="polite">{displayTime}</span>
+            {#if label}<span class="cook-timer-name">{label}</span>{/if}
+        </button>
+    </span>
+
+    {#if selectorOpen}
+        <span
+            bind:this={popoverElement}
+            class="cook-timer-range-popover"
+            class:cook-timer-range-ready={selectorReady}
+            role="dialog"
+            tabindex="-1"
+            aria-label={`Choose duration for ${label || 'timer'}`}
+            style={`left: ${popoverLeft}px;`}
+        >
+            <span class="cook-timer-range-header">
+                <span class="cook-timer-range-value" aria-live="polite">{formatTime(selectedSeconds)}</span>
+                <button
+                    type="button"
+                    class="cook-timer-range-close"
+                    aria-label="Close timer range selector"
+                    onclick={closeFromButton}
+                >×</button>
+            </span>
+            <input
+                bind:this={sliderElement}
+                class="cook-timer-range-slider"
+                type="range"
+                min={duration.minimumSeconds}
+                max={duration.maximumSeconds}
+                step={sliderStep}
+                value={selectedSeconds}
+                aria-label={`Duration for ${label || 'timer'}`}
+                aria-valuetext={formatTime(selectedSeconds)}
+                aria-describedby={sliderHelpId}
+                oninput={updateSelection}
+                onpointerup={startSelected}
+                onkeydown={handleSliderKeydown}
+            />
+            <span class="cook-timer-range-bounds" aria-hidden="true">
+                <span>{formatTime(duration.minimumSeconds)}</span>
+                <span>{formatTime(duration.maximumSeconds)}</span>
+            </span>
+            <span id={sliderHelpId} class="cook-timer-range-help">
+                Release the slider to start. Press Enter when using the keyboard.
+            </span>
+        </span>
+    {/if}
+</span>

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -34,7 +34,8 @@ export interface RecipeHostAdapter {
 
 export interface TimerController {
     toggle(key: string, seconds: number, label: string): void;
-    subscribe(key: string, listener: (snapshot: TimerSnapshot) => void): () => void;
+    reset(key: string): void;
+    subscribe(key: string, listener: (snapshot: TimerSnapshot | null) => void): () => void;
 }
 
 export interface RecipeRenderModel {

--- a/src/utils/timeFormatters.test.ts
+++ b/src/utils/timeFormatters.test.ts
@@ -5,6 +5,7 @@ import {
     DEFAULT_MINUTES_LABELS,
     DEFAULT_SECONDS_LABELS,
     formatTimerDuration,
+    timerRangeStep,
     timerDurationFromQuantity,
 } from './timeFormatters';
 
@@ -93,5 +94,16 @@ describe('timerDurationFromQuantity', () => {
         const localized = createUnitMap('minuto', 'hora', 'segundo');
         expect(timerDurationFromQuantity(text('1HORA 2MINUTO 3SEGUNDO'), localized))
             .toEqual({ minimumSeconds: 3723, maximumSeconds: 3723 });
+    });
+});
+
+describe('timerRangeStep', () => {
+    it('uses minute steps when both bounds are whole minutes', () => {
+        expect(timerRangeStep({ minimumSeconds: 600, maximumSeconds: 900 })).toBe(60);
+    });
+
+    it('uses second steps when either bound includes seconds', () => {
+        expect(timerRangeStep({ minimumSeconds: 30, maximumSeconds: 90 })).toBe(1);
+        expect(timerRangeStep({ minimumSeconds: 60, maximumSeconds: 90 })).toBe(1);
     });
 });

--- a/src/utils/timeFormatters.ts
+++ b/src/utils/timeFormatters.ts
@@ -50,6 +50,13 @@ export function formatTimerDuration(duration: TimerDuration): string {
     return `${minimum}–${formatTime(duration.maximumSeconds)}`;
 }
 
+/** Choose a natural slider step for a timer range. */
+export function timerRangeStep(duration: TimerDuration): number {
+    return duration.minimumSeconds % 60 === 0 && duration.maximumSeconds % 60 === 0
+        ? 60
+        : 1;
+}
+
 /**
  * Creates a unit map for converting time units to seconds
  * @param minutesLabel - Comma-separated labels for minutes (e.g., "m,min,minute,minutes")


### PR DESCRIPTION
## Summary

- open an anchored slider when an inline Cooklang timer contains a duration range
- start the selected duration on slider release while preserving fixed-duration click behavior
- let active timers pause, resume, and reset so an incorrect range choice can be replaced
- keep the combined timer chip dimensionally stable and animate its theme-aware color while running

## Why

Range quantities were parsed with both bounds, but the timer control always started the minimum duration. Users had no way to choose another value in the range, and no way to cancel an incorrect selection and choose again.

The new selector exposes the full parsed range without changing parser behavior or persisted view state. Reset removes the keyed countdown and returns the control to its idle range.

## UX and accessibility

- positions the selector immediately below the inline timer and clamps it within the recipe pane
- uses minute steps for whole-minute bounds and second steps otherwise
- supports Enter to start, Escape and outside click to dismiss, focus restoration, and accessible labels
- keeps reset and countdown controls inside one shared chip without changing surrounding text wrapping
- respects custom Obsidian theme variables and `prefers-reduced-motion`

## Validation

- `npm test` — 92 tests passed
- `npm run build` — passed
