### PR TITLE
feat: show changelog after plugin updates

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import url from '@rollup/plugin-url';
 import wasm from '@rollup/plugin-wasm';
 import svelte from 'rollup-plugin-svelte';
 import * as sass from 'sass';
+import {readFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import svelteConfig from './svelte.config.js';
 
@@ -37,6 +38,19 @@ function sassStyles() {
         fileName: 'styles.css',
         source: css
       });
+    }
+  };
+}
+
+function markdownString() {
+  return {
+    name: 'markdown-string',
+    load(id) {
+      if (!id.endsWith('.md')) {
+        return null;
+      }
+
+      return `export default ${JSON.stringify(readFileSync(id, 'utf8'))};`;
     }
   };
 }
@@ -99,6 +113,7 @@ export default {
     commonjs({
       include: ['node_modules/**', 'src/mode/**']
     }),
+    markdownString(),
     sassStyles(),
     url({
       include: ['**/*.mp3'],

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,9 @@ import { ObsidianRecipeHost } from './ui/ObsidianRecipeHost';
 import { createUiInstanceId } from './ui/instanceIds';
 import type { EmbedRenderState } from './ui/types';
 import { embedSettings } from './utils/embedSettings';
+import changelog from '../CHANGELOG.md';
+import { ChangelogModal } from './ui/ChangelogModal';
+import { releaseNotesForUpdate } from './utils/releaseNotes';
 
 export default class CookPlugin extends Plugin {
 
@@ -27,7 +30,9 @@ export default class CookPlugin extends Plugin {
 
   async onload() {
     super.onload();
-    this.settings = Object.assign(new CooklangSettings(), await this.loadData());
+    const storedData = await this.loadData();
+    const isFirstInstall = storedData == null;
+    this.settings = Object.assign(new CooklangSettings(), storedData ?? {});
 
     // register a custom icon
     this.addDocumentIcon("cook");
@@ -311,6 +316,39 @@ export default class CookPlugin extends Plugin {
           }
         });
       }
+    });
+
+    await this.showReleaseNotesAfterUpdate(isFirstInstall);
+  }
+
+  private async showReleaseNotesAfterUpdate(isFirstInstall: boolean): Promise<void> {
+    const currentVersion = this.manifest.version;
+    const previousVersion = this.settings.lastSeenVersion;
+
+    if (previousVersion === currentVersion) return;
+
+    this.settings.lastSeenVersion = currentVersion;
+    try {
+      await this.saveData(this.settings);
+    } catch (error) {
+      console.error('Could not save the Cooklang release-notes version.', error);
+    }
+
+    const notes = releaseNotesForUpdate(
+      changelog,
+      currentVersion,
+      previousVersion,
+      isFirstInstall,
+    );
+    if (!notes) return;
+
+    this.app.workspace.onLayoutReady(() => {
+      new ChangelogModal(
+        this.app,
+        this.manifest.name,
+        currentVersion,
+        notes,
+      ).open();
     });
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,8 @@ declare class CookPlugin extends Plugin {
 }
 
 export class CooklangSettings {
+  /** Internal marker used to show release notes only once per plugin version. */
+  lastSeenVersion?: string;
   showImages: boolean = true;
   showIngredientList: boolean = true;
   showCookwareList: boolean = true;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -419,6 +419,14 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
   margin-bottom: var(--size-2-2, 6px);
 }
 
+/* Release notes shown once after a plugin update. */
+.cook-changelog-modal {
+  width: min(680px, calc(100vw - 32px));
+}
+.cook-changelog > h2:first-child {
+  margin-top: 0;
+}
+
 /* Per-section ingredient sub-headings (#69) */
 .cook-ing-group-title {
   margin: var(--size-4-3, 12px) 0 var(--size-2-2, 6px);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,3 +2,8 @@ declare module '*.mp3' {
     const content: string;
     export default content;
 }
+
+declare module '*.md' {
+    const content: string;
+    export default content;
+}

--- a/src/ui/ChangelogModal.ts
+++ b/src/ui/ChangelogModal.ts
@@ -1,0 +1,31 @@
+import { Component, MarkdownRenderer, Modal, type App } from 'obsidian';
+
+export class ChangelogModal extends Modal {
+    private renderComponent: Component | null = null;
+
+    constructor(
+        app: App,
+        private pluginName: string,
+        private version: string,
+        private releaseNotes: string,
+    ) {
+        super(app);
+    }
+
+    async onOpen(): Promise<void> {
+        this.contentEl.empty();
+        this.titleEl.setText(`What's new in ${this.pluginName} ${this.version}`);
+        this.modalEl.addClass('cook-changelog-modal');
+
+        const notesEl = this.contentEl.createDiv({ cls: 'cook-changelog markdown-rendered' });
+        this.renderComponent = new Component();
+        this.renderComponent.load();
+        await MarkdownRenderer.render(this.app, this.releaseNotes, notesEl, '', this.renderComponent);
+    }
+
+    onClose(): void {
+        this.renderComponent?.unload();
+        this.renderComponent = null;
+        this.contentEl.empty();
+    }
+}

--- a/src/utils/releaseNotes.test.ts
+++ b/src/utils/releaseNotes.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { compareVersions, releaseNotesForUpdate, releaseNotesSince } from './releaseNotes';
+
+const changelog = `# Changelog
+
+## [1.3.0](https://example.com/1.3.0) (2026-08-10)
+
+### Features
+
+* newest feature
+
+## [1.2.0](https://example.com/1.2.0) (2026-08-01)
+
+### Bug Fixes
+
+* middle fix
+
+## 1.1.0
+
+### Added
+
+* oldest feature
+`;
+
+describe('compareVersions', () => {
+    it('compares semantic versions including prereleases', () => {
+        expect(compareVersions('1.3.0', '1.2.9')).toBeGreaterThan(0);
+        expect(compareVersions('1.3.0-beta.2', '1.3.0-beta.10')).toBeLessThan(0);
+        expect(compareVersions('1.3.0', '1.3.0-beta.10')).toBeGreaterThan(0);
+        expect(compareVersions('not-a-version', '1.3.0')).toBeNull();
+    });
+});
+
+describe('releaseNotesSince', () => {
+    it('returns only the current release when no previous version is known', () => {
+        const notes = releaseNotesSince(changelog, '1.3.0');
+
+        expect(notes).toContain('newest feature');
+        expect(notes).not.toContain('middle fix');
+    });
+
+    it('returns every release missed since the previous version', () => {
+        const notes = releaseNotesSince(changelog, '1.3.0', '1.1.0');
+
+        expect(notes).toContain('newest feature');
+        expect(notes).toContain('middle fix');
+        expect(notes).not.toContain('oldest feature');
+    });
+
+    it('does not return notes for the same version or a downgrade', () => {
+        expect(releaseNotesSince(changelog, '1.3.0', '1.3.0')).toBeNull();
+        expect(releaseNotesSince(changelog, '1.2.0', '1.3.0')).toBeNull();
+    });
+
+    it('returns null when the current release is absent from the changelog', () => {
+        expect(releaseNotesSince(changelog, '2.0.0', '1.1.0')).toBeNull();
+    });
+});
+
+describe('releaseNotesForUpdate', () => {
+    it('suppresses release notes on a fresh installation', () => {
+        expect(releaseNotesForUpdate(changelog, '1.3.0', undefined, true)).toBeNull();
+    });
+
+    it('shows the current notes when upgrading from a version without a marker', () => {
+        const notes = releaseNotesForUpdate(changelog, '1.3.0', undefined, false);
+
+        expect(notes).toContain('newest feature');
+        expect(notes).not.toContain('middle fix');
+    });
+});

--- a/src/utils/releaseNotes.ts
+++ b/src/utils/releaseNotes.ts
@@ -1,0 +1,126 @@
+interface ParsedVersion {
+    core: [number, number, number];
+    prerelease: string[];
+}
+
+interface ChangelogSection {
+    version: string;
+    markdown: string;
+}
+
+const VERSION_PATTERN = '(\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)';
+const RELEASE_HEADING = new RegExp(
+    `^##[ \\t]+(?:\\[v?${VERSION_PATTERN}\\]\\([^)]+\\)|v?${VERSION_PATTERN})(?:[ \\t].*)?$`,
+    'gm',
+);
+
+function parseVersion(version: string): ParsedVersion | null {
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(version);
+    if (!match) return null;
+
+    return {
+        core: [Number(match[1]), Number(match[2]), Number(match[3])],
+        prerelease: match[4]?.split('.') ?? [],
+    };
+}
+
+function compareIdentifiers(left: string, right: string): number {
+    const leftNumber = /^\d+$/.test(left) ? Number(left) : null;
+    const rightNumber = /^\d+$/.test(right) ? Number(right) : null;
+
+    if (leftNumber !== null && rightNumber !== null) return leftNumber - rightNumber;
+    if (leftNumber !== null) return -1;
+    if (rightNumber !== null) return 1;
+    return left.localeCompare(right);
+}
+
+export function compareVersions(left: string, right: string): number | null {
+    const parsedLeft = parseVersion(left);
+    const parsedRight = parseVersion(right);
+    if (!parsedLeft || !parsedRight) return null;
+
+    for (let index = 0; index < parsedLeft.core.length; index += 1) {
+        const difference = parsedLeft.core[index] - parsedRight.core[index];
+        if (difference !== 0) return difference;
+    }
+
+    if (parsedLeft.prerelease.length === 0 && parsedRight.prerelease.length === 0) return 0;
+    if (parsedLeft.prerelease.length === 0) return 1;
+    if (parsedRight.prerelease.length === 0) return -1;
+
+    const identifierCount = Math.max(parsedLeft.prerelease.length, parsedRight.prerelease.length);
+    for (let index = 0; index < identifierCount; index += 1) {
+        const leftIdentifier = parsedLeft.prerelease[index];
+        const rightIdentifier = parsedRight.prerelease[index];
+        if (leftIdentifier === undefined) return -1;
+        if (rightIdentifier === undefined) return 1;
+
+        const difference = compareIdentifiers(leftIdentifier, rightIdentifier);
+        if (difference !== 0) return difference;
+    }
+
+    return 0;
+}
+
+function changelogSections(changelog: string): ChangelogSection[] {
+    const matches = Array.from(changelog.matchAll(RELEASE_HEADING));
+
+    return matches.map((match, index) => ({
+        version: match[1] ?? match[2],
+        markdown: changelog
+            .slice(match.index, matches[index + 1]?.index ?? changelog.length)
+            .trim(),
+    }));
+}
+
+/**
+ * Returns the release sections newer than the last version the user saw.
+ * With no usable previous version, only the current release is returned. The
+ * caller separately suppresses this for a fresh install; this fallback lets
+ * users upgrading from a version that predates the stored marker see what's new.
+ */
+export function releaseNotesSince(
+    changelog: string,
+    currentVersion: string,
+    previousVersion?: string,
+): string | null {
+    const currentComparison = compareVersions(currentVersion, currentVersion);
+    if (currentComparison === null) return null;
+
+    const previousComparison = previousVersion
+        ? compareVersions(previousVersion, currentVersion)
+        : null;
+    if (previousComparison !== null && previousComparison >= 0) return null;
+
+    const sections = changelogSections(changelog);
+    const hasCurrentRelease = sections.some(
+        section => compareVersions(section.version, currentVersion) === 0,
+    );
+    if (!hasCurrentRelease) return null;
+
+    const selected = previousComparison === null
+        ? sections.filter(section => compareVersions(section.version, currentVersion) === 0)
+        : sections.filter(section => {
+            const afterPrevious = compareVersions(section.version, previousVersion as string);
+            const atOrBeforeCurrent = compareVersions(section.version, currentVersion);
+            return afterPrevious !== null
+                && afterPrevious > 0
+                && atOrBeforeCurrent !== null
+                && atOrBeforeCurrent <= 0;
+        });
+
+    return selected.length > 0
+        ? selected.map(section => section.markdown).join('\n\n')
+        : null;
+}
+
+export function releaseNotesForUpdate(
+    changelog: string,
+    currentVersion: string,
+    previousVersion: string | undefined,
+    isFirstInstall: boolean,
+): string | null {
+    return isFirstInstall
+        ? null
+        : releaseNotesSince(changelog, currentVersion, previousVersion);
+}


### PR DESCRIPTION
## Summary

- embed `CHANGELOG.md` in the production bundle and render release sections in a native Obsidian modal
- persist the last-seen plugin version so release notes appear once after an update
- suppress the modal on fresh installations while supporting upgrades from versions that predate the marker
- include all missed releases when users skip versions

## User impact

After updating Cooklang Editor, users see the relevant release notes once Obsidian's workspace is ready. Installing the plugin for the first time, restarting Obsidian, or re-enabling the same version does not show the modal.

## Validation

- `npm test` (89 tests passed)
- `npm run build`
- `git diff --check`
