### PR TITLE
fix: refine timer range slider UI

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -435,7 +435,8 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-range-popover.cook-timer-range-ready { opacity: 1; pointer-events: auto; }
 .cook-timer-range-header {
   display: flex; align-items: center; justify-content: space-between; gap: var(--size-4-2, 8px);
-  margin-bottom: var(--size-2-2, 6px);
+  // The custom WebKit thumb extends 7px above its track.
+  margin-bottom: var(--size-4-3, 12px);
 }
 .cook-timer-range-value { font-size: 1.05em; font-weight: 600; font-variant-numeric: tabular-nums; }
 .cook-timer-range-close {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -435,21 +435,51 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-range-popover.cook-timer-range-ready { opacity: 1; pointer-events: auto; }
 .cook-timer-range-header {
   display: flex; align-items: center; justify-content: space-between; gap: var(--size-4-2, 8px);
-  margin-bottom: var(--size-4-2, 8px);
+  margin-bottom: var(--size-2-2, 6px);
 }
-.cook-timer-range-value { font-weight: 600; font-variant-numeric: tabular-nums; }
+.cook-timer-range-value { font-size: 1.05em; font-weight: 600; font-variant-numeric: tabular-nums; }
 .cook-timer-range-close {
-  width: 28px; height: 28px; padding: 0; border: 0; border-radius: var(--radius-s, 4px);
-  background: transparent; color: var(--text-muted); cursor: pointer; font: inherit; font-size: 1.25em;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0; border: 0; border-radius: var(--radius-s, 4px);
+  appearance: none; background: transparent !important; box-shadow: none !important;
+  color: var(--text-muted); cursor: pointer; font: inherit; font-size: 1.1em; line-height: 1;
 }
-.cook-timer-range-close:hover { background: var(--background-modifier-hover); color: var(--text-normal); }
-.cook-timer-range-slider { display: block; width: 100%; margin: 0; accent-color: var(--interactive-accent); }
+.cook-timer-range-close:hover {
+  background: var(--background-modifier-hover) !important; color: var(--text-normal);
+}
+.cook-timer-range-slider {
+  display: block; width: 100% !important; max-width: none !important; height: 24px;
+  margin: 0 !important; padding: 0 !important; border: 0;
+  appearance: none; -webkit-appearance: none;
+  background: transparent !important; box-shadow: none !important; cursor: pointer;
+}
+.cook-timer-range-slider::-webkit-slider-runnable-track {
+  width: 100%; height: 4px; border: 0; border-radius: 999px;
+  background: var(--background-modifier-border-hover, var(--background-modifier-border));
+}
+.cook-timer-range-slider::-webkit-slider-thumb {
+  width: 18px; height: 18px; margin-top: -7px; border: 2px solid var(--interactive-accent);
+  border-radius: 50%; -webkit-appearance: none;
+  background: var(--background-primary); box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
+}
+.cook-timer-range-slider::-moz-range-track {
+  width: 100%; height: 4px; border: 0; border-radius: 999px;
+  background: var(--background-modifier-border-hover, var(--background-modifier-border));
+}
+.cook-timer-range-slider::-moz-range-progress {
+  height: 4px; border-radius: 999px; background: var(--interactive-accent);
+}
+.cook-timer-range-slider::-moz-range-thumb {
+  width: 18px; height: 18px; border: 2px solid var(--interactive-accent); border-radius: 50%;
+  background: var(--background-primary); box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
+}
 .cook-timer-range-bounds {
-  display: flex; justify-content: space-between; margin-top: var(--size-2-1, 4px);
+  display: flex; justify-content: space-between; margin-top: 0;
   color: var(--text-muted); font-size: var(--font-ui-smaller); font-variant-numeric: tabular-nums;
 }
 .cook-timer-range-help {
-  display: block; margin-top: var(--size-4-2, 8px); color: var(--text-faint); font-size: var(--font-ui-smaller);
+  display: block; margin-top: var(--size-4-2, 8px); color: var(--text-faint);
+  font-size: var(--font-ui-smaller); line-height: 1.3; white-space: nowrap;
 }
 
 /* Notes */

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -266,6 +266,7 @@ describe('TimerButton', () => {
         expect((slider as HTMLInputElement).value).toBe('60');
         expect(screen.getAllByText('1:00')).toHaveLength(2);
         expect(screen.getByText('3:00')).toBeTruthy();
+        expect(screen.getByText('Release to start · Keyboard: Enter')).toBeTruthy();
         expect(controller.toggle).not.toHaveBeenCalled();
 
         await fireEvent.input(slider, { target: { value: '120' } });

--- a/src/ui/components/TimerButton.svelte
+++ b/src/ui/components/TimerButton.svelte
@@ -219,7 +219,7 @@
                 <span>{formatTime(duration.maximumSeconds)}</span>
             </span>
             <span id={sliderHelpId} class="cook-timer-range-help">
-                Release the slider to start. Press Enter when using the keyboard.
+                Release to start · Keyboard: Enter
             </span>
         </span>
     {/if}


### PR DESCRIPTION
## Summary

- make the timer-range track fill the popover instead of inheriting Obsidian's short default range width
- use a compact, theme-aware track, thumb, and close control
- shorten the interaction guidance so it stays on one line

## Root cause

Global Obsidian theme styles were leaking into the native range input and close button. This produced a short track, oversized thumb, and prominent button background inside the otherwise compact timer popover.

The slider and close control now have scoped `cook-` styles that consistently override those global defaults while continuing to use Obsidian semantic color variables.

## Validation

- `npm test` — 99 tests passed
- `npm run build` — passed
