### PR TITLE
fix: improve mobile WebView compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,12 +91,24 @@ fenced `cook` / `cooklang` block in Markdown reading mode
 - Avoid broad edits to the legacy `src/lib/codemirror.js` stub; current syntax support lives in `src/mode/cook/` and CodeMirror 6 packages.
 - Preserve the README's privacy promise. Do not introduce telemetry, data collection, or outbound network behavior without an explicit product decision and matching documentation.
 
+## Mobile WebView compatibility
+
+- Treat iOS WKWebView and Android WebView as first-class runtimes. Prefer semantic `button`, `a`, `input`, `label`, `details`, and `summary` elements so keyboard, touch, assistive technology, and synthesized click behavior share one path.
+- Use `click` or `change` for discrete actions. Reserve pointer events for continuous gestures such as sliders, and do not add parallel touch and mouse handlers for the same interaction.
+- Do not synchronously remove, replace, or rerender an active pointer target from its `pointerup` or `pointercancel` handler. Range inputs can use implicit pointer capture; release capture when present and defer teardown until a later task so Android WebView can finish pointer cleanup and restore scrolling.
+- Keep vertical page scrolling available when adding horizontal gesture controls. A horizontal range control should declare `touch-action: pan-y`, and document-level pointer listeners must not call `preventDefault()` unless blocking native scrolling is explicitly required.
+- Give custom controls coarse-pointer hit areas of at least 48 CSS pixels where layout permits. Keep their visible glyphs compact with padding, and preserve spacing between adjacent actions. Scope hover-only feedback to `(hover: hover) and (pointer: fine)` and provide `:active` feedback for touch.
+- Include both `appearance: none` and `-webkit-appearance: none` when replacing native form-control styling. Keep focus-visible outlines, accessible names, and keyboard behavior intact.
+- Programmatic focus after a reactive render should use `{ preventScroll: true }` with a fallback, especially for popovers and range inputs. Avoid `aria-live` on values that update every second or continuously while dragging; the control's accessible name or `aria-valuetext` should expose the current value without flooding VoiceOver or TalkBack.
+- Avoid viewport-width sizing inside padded panes; prefer container-relative `width: 100%`, `max-width: 100%`, and `box-sizing: border-box`. Lazy-load below-the-fold step images to reduce memory and decoding pressure on mobile.
+
 ## Testing and definition of done
 
 - Add or update a colocated `*.test.ts` when changing pure behavior. Vitest discovers `src/**/*.test.ts`.
 - Avoid runtime imports from `obsidian` in Node tests. Extract pure logic instead of trying to instantiate Obsidian views in Vitest.
 - Run the narrowest relevant test while iterating, then run `npm test` and `npm run build` before handing off a code change.
 - DOM, lifecycle, or CSS changes also need proportionate manual verification in Obsidian because there is no automated Obsidian integration suite. Rebuild, reload/re-enable the plugin, and check the affected source/preview flow. For layout changes, check light and dark themes plus a narrow pane/mobile-sized view; for shared renderers, also check fenced Markdown embeds.
+- For touch interaction changes, manually verify both iOS and Android when devices are available: drag and release sliders, immediately scroll from the former control area, tap every adjacent action, rotate the device, and confirm VoiceOver/TalkBack does not announce continuous timer ticks.
 - A local manual setup can symlink the repository into `<vault>/.obsidian/plugins/cooklang-obsidian`; `test-recipes/curry.cook` is the starting fixture.
 - Treat build warnings separately from failures, but confirm that `main.js` and `styles.css` were actually produced.
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -18,11 +18,13 @@
 
   .cook-source-view-full {
     height: 100%;
+    width: 100%;
+    box-sizing: border-box;
     padding: 0 20px;
   }
 
   .main-image {
-    width: 100vw;
+    width: 100%;
     aspect-ratio: 1.618;
     object-fit: cover;
   }
@@ -205,6 +207,8 @@
    container rule must be a compound selector (no descendant combinator). */
 .cook-preview-view.cook-rich {
   container-type: inline-size;
+  box-sizing: border-box;
+  width: 100%;
   max-width: 1000px;
   margin: 0 auto;
   padding: 0 var(--size-4-4, 16px) var(--size-4-8, 32px);
@@ -238,7 +242,6 @@
   overflow-wrap: anywhere;
   text-decoration: none;
 }
-a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent); }
 .cook-pill-icon { flex: 0 0 auto; opacity: 0.85; }
 .cook-pill-tag { background: transparent; border-color: var(--text-accent); color: var(--text-accent); }
 
@@ -253,16 +256,15 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 }
 .cook-bar-nav { display: flex; gap: var(--size-4-4, 16px); }
 .cook-bar-link { font-size: 0.85em; font-weight: 600; color: var(--text-muted); text-decoration: none; }
-.cook-bar-link:hover { color: var(--text-accent); }
 .cook-stepper {
   margin-left: auto; display: flex; align-items: center; gap: 6px;
   border: 1px solid var(--background-modifier-border); border-radius: 14px; height: 30px; padding: 0 6px;
 }
 .cook-stepper-btn {
   width: 22px; height: 22px; border: none; border-radius: 50%;
+  -webkit-appearance: none; appearance: none;
   background: transparent; color: var(--text-muted); font-size: 1em; cursor: pointer; line-height: 1;
 }
-.cook-stepper-btn:hover { background: var(--background-modifier-hover); color: var(--text-normal); }
 .cook-stepper-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .cook-stepper-val { font-size: 0.85em; font-variant-numeric: tabular-nums; }
 .cook-stepper-val b { color: var(--text-normal); }
@@ -298,10 +300,11 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 }
 .cook-ing:last-child { border-bottom: none; }
 .cook-ing-checkbox {
-  appearance: none; margin: 0; padding: 0;
+  -webkit-appearance: none; appearance: none; margin: 0; padding: 0;
   width: 17px; height: 17px; flex: none; border-radius: 5px;
   border: 1.5px solid var(--text-faint); background: transparent; cursor: pointer;
 }
+.cook-ing-checkbox-hit { display: inline-flex; flex: none; }
 .cook-ing-checkbox:checked {
   background: var(--interactive-accent); border-color: var(--interactive-accent); position: relative;
 }
@@ -350,11 +353,12 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-step-toggle {
   align-self: flex-start; min-width: 28px; min-height: 28px; margin: -4px 0 0 -6px;
   padding: 4px 6px; border: 0; border-radius: var(--radius-s, 4px);
-  background: transparent; cursor: pointer; font: inherit;
+  -webkit-appearance: none; appearance: none; background: transparent; cursor: pointer; font: inherit;
 }
-.cook-step-toggle:hover { background: var(--background-modifier-hover); }
 .cook-step-bodywrap { flex: 1; min-width: 0; }
 .cook-step-text { line-height: 1.6; }
+.cook-ingredients,
+.cook-steps { scroll-margin-top: 64px; }
 .cook-step-image { margin: var(--size-4-2, 8px) 0 0; }
 .cook-step-image img { max-width: 100%; border-radius: var(--radius-m, 8px); }
 
@@ -366,7 +370,6 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
   text-underline-offset: 2px;
   cursor: pointer;
 }
-.cook-ref-link:hover { text-decoration-style: solid; }
 .cook-ref-missing { color: var(--text-muted); font-style: italic; }
 
 /* Inline components */
@@ -376,20 +379,19 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-btn {
   display: inline-flex; align-items: center; gap: 0.25em;
   min-width: 0; min-height: 22px; padding: 0; border: 0;
-  appearance: none; background: transparent !important; box-shadow: none !important;
+  -webkit-appearance: none; appearance: none; background: transparent !important; box-shadow: none !important;
   color: inherit; cursor: pointer; font: inherit;
 }
-.cook-timer-name { margin-inline-start: 0.25em; }
+.cook-timer-name { margin-inline-start: 0.25em; overflow-wrap: anywhere; }
 .cook-timer-range-anchor {
-  position: relative; display: inline-block; vertical-align: middle;
+  position: relative; display: inline-block; max-width: 100%; vertical-align: middle;
 }
 .cook-timer-chip {
   display: inline-flex; align-items: center; gap: 0.25em;
-  box-sizing: border-box; min-height: 26px; padding: 1px 8px;
+  box-sizing: border-box; max-width: 100%; min-height: 26px; padding: 1px 8px;
   background: var(--background-secondary); border: 1px solid var(--text-accent); color: var(--text-accent);
   border-radius: 13px; font-size: 0.9em;
 }
-.cook-timer-chip:hover { background: var(--background-modifier-hover); }
 .cook-timer-chip.cook-timer-running {
   animation: cook-timer-border-pulse 1.6s ease-in-out infinite;
 }
@@ -415,7 +417,7 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-icon { display: inline-block; flex: 0 0 1em; width: 1em; text-align: center; }
 .cook-timer-reset-btn {
   flex: 0 0 1em; width: 1em; height: 22px; padding: 0; border: 0; border-radius: 4px;
-  appearance: none; background: transparent !important; box-shadow: none !important;
+  -webkit-appearance: none; appearance: none; background: transparent !important; box-shadow: none !important;
   color: inherit; cursor: pointer; font: inherit;
 }
 .cook-timer-chip .cook-timer-btn:hover,
@@ -442,17 +444,15 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-range-close {
   display: inline-flex; align-items: center; justify-content: center;
   width: 24px; height: 24px; padding: 0; border: 0; border-radius: var(--radius-s, 4px);
-  appearance: none; background: transparent !important; box-shadow: none !important;
+  -webkit-appearance: none; appearance: none; background: transparent !important; box-shadow: none !important;
   color: var(--text-muted); cursor: pointer; font: inherit; font-size: 1.1em; line-height: 1;
-}
-.cook-timer-range-close:hover {
-  background: var(--background-modifier-hover) !important; color: var(--text-normal);
 }
 .cook-timer-range-slider {
   display: block; width: 100% !important; max-width: none !important; height: 24px;
   margin: 0 !important; padding: 0 !important; border: 0;
   appearance: none; -webkit-appearance: none;
   background: transparent !important; box-shadow: none !important; cursor: pointer;
+  touch-action: pan-y;
 }
 .cook-timer-range-slider::-webkit-slider-runnable-track {
   width: 100%; height: 4px; border: 0; border-radius: 999px;
@@ -473,6 +473,58 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 .cook-timer-range-slider::-moz-range-thumb {
   width: 18px; height: 18px; border: 2px solid var(--interactive-accent); border-radius: 50%;
   background: var(--background-primary); box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent); }
+  .cook-bar-link:hover { color: var(--text-accent); }
+  .cook-stepper-btn:hover { background: var(--background-modifier-hover); color: var(--text-normal); }
+  .cook-step-toggle:hover { background: var(--background-modifier-hover); }
+  .cook-ref-link:hover { text-decoration-style: solid; }
+  .cook-timer-chip:hover { background: var(--background-modifier-hover); }
+  .cook-timer-range-close:hover {
+    background: var(--background-modifier-hover) !important; color: var(--text-normal);
+  }
+}
+
+@media (hover: none) {
+  a.cook-pill:active { color: var(--text-normal); border-color: var(--text-accent); }
+  .cook-bar-link:active { color: var(--text-accent); }
+  .cook-stepper-btn:active,
+  .cook-step-toggle:active { background: var(--background-modifier-hover); color: var(--text-normal); }
+  .cook-ref-link:active { text-decoration-style: solid; }
+  .cook-timer-btn:active,
+  .cook-timer-reset-btn:active { opacity: 0.7; }
+  .cook-timer-range-close:active {
+    background: var(--background-modifier-hover) !important; color: var(--text-normal);
+  }
+}
+
+@media (pointer: coarse) {
+  a.cook-pill,
+  .cook-bar-link {
+    display: inline-flex; align-items: center; min-height: 48px;
+  }
+  .cook-stepper { height: 50px; border-radius: 25px; padding: 0; }
+  .cook-stepper-btn { width: 48px; height: 48px; }
+  .cook-ing { min-height: 48px; }
+  .cook-ing-checkbox-hit {
+    align-items: center; justify-content: center;
+    width: 48px; min-height: 48px; margin-block: -7px;
+  }
+  .cook-step-toggle {
+    min-width: 48px; min-height: 48px; margin: -10px 0 -10px -10px;
+  }
+  .cook-timer-chip { min-height: 52px; border-radius: 26px; padding-block: 1px; }
+  .cook-timer-btn { min-width: 48px; min-height: 48px; }
+  .cook-timer-reset-btn { flex-basis: 48px; width: 48px; height: 48px; }
+  .cook-timer-range-close { width: 48px; height: 48px; }
+  .cook-timer-range-slider { height: 48px; }
+  .cook-timer-range-slider::-webkit-slider-thumb {
+    width: 24px; height: 24px; margin-top: -10px;
+  }
+  .cook-timer-range-slider::-moz-range-thumb { width: 24px; height: 24px; }
+  .cook-more-summary { display: flex; align-items: center; min-height: 48px; }
 }
 .cook-timer-range-bounds {
   display: flex; justify-content: space-between; margin-top: 0;
@@ -527,6 +579,7 @@ a.cook-pill:hover { color: var(--text-normal); border-color: var(--text-accent);
 /* Release notes shown once after a plugin update. */
 .cook-changelog-modal {
   width: min(680px, calc(100vw - 32px));
+  max-width: 100%;
 }
 .cook-changelog > h2:first-child {
   margin-top: 0;

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -162,7 +162,9 @@ describe('RecipePreview', () => {
         expect(screen.getByText('2:00–4:00')).toBeTruthy();
         expect(screen.getByText('220 C')).toBeTruthy();
 
-        await fireEvent.click(screen.getByRole('checkbox', { name: 'Check flour' }));
+        const checkbox = screen.getByRole('checkbox', { name: 'Check flour' });
+        expect(checkbox.closest('label')?.classList.contains('cook-ing-checkbox-hit')).toBe(true);
+        await fireEvent.click(checkbox);
         expect(renderModel.callbacks.onIngredientToggle).toHaveBeenCalledWith('flour');
 
         await fireEvent.click(screen.getByRole('button', { name: 'More servings' }));
@@ -236,9 +238,10 @@ describe('TimerButton', () => {
         await fireEvent.click(screen.getByRole('button', { name: 'Start rest (1:00)' }));
         expect(controller.toggle).toHaveBeenCalledOnce();
         expect(controller.toggle).toHaveBeenCalledWith('timer', 60, 'rest');
+        expect(screen.queryByText('1:00')?.closest('[aria-live]')).toBeNull();
     });
 
-    it('opens a range selector and starts the selected duration on pointer release', async () => {
+    it('releases pointer capture before starting the selected range duration', async () => {
         const controller: TimerController = {
             toggle: vi.fn(),
             reset: vi.fn(),
@@ -267,11 +270,22 @@ describe('TimerButton', () => {
         expect(screen.getAllByText('1:00')).toHaveLength(2);
         expect(screen.getByText('3:00')).toBeTruthy();
         expect(screen.getByText('Release to start · Keyboard: Enter')).toBeTruthy();
+        expect(dialog.querySelector('[aria-live]')).toBeNull();
         expect(controller.toggle).not.toHaveBeenCalled();
 
         await fireEvent.input(slider, { target: { value: '120' } });
         expect(slider.getAttribute('aria-valuetext')).toBe('2:00');
-        await fireEvent.pointerUp(slider);
+        const hasPointerCapture = vi.fn(() => true);
+        const releasePointerCapture = vi.fn();
+        Object.assign(slider, { hasPointerCapture, releasePointerCapture });
+        await fireEvent.pointerUp(slider, { pointerId: 7 });
+
+        expect(hasPointerCapture).toHaveBeenCalledWith(7);
+        expect(releasePointerCapture).toHaveBeenCalledWith(7);
+        expect(controller.toggle).not.toHaveBeenCalled();
+        expect(screen.getByRole('dialog')).toBeTruthy();
+
+        await new Promise(resolve => window.setTimeout(resolve, 0));
 
         expect(controller.toggle).toHaveBeenCalledOnce();
         expect(controller.toggle).toHaveBeenCalledWith('timer', 120, 'rest');
@@ -359,6 +373,7 @@ describe('TimerButton', () => {
         const slider = screen.getByRole('slider');
         await fireEvent.input(slider, { target: { value: '180' } });
         await fireEvent.pointerUp(slider);
+        await new Promise(resolve => window.setTimeout(resolve, 0));
         expect(controller.toggle).toHaveBeenCalledWith('timer', 180, 'rest');
     });
 

--- a/src/ui/components/IngredientList.svelte
+++ b/src/ui/components/IngredientList.svelte
@@ -20,14 +20,16 @@
                     {@const checked = model.state.checkedIngredients.has(row.name)}
                     <li class:done={checked} class="cook-ing">
                         {#if model.interactive}
-                            <input
-                                id={inputId}
-                                class="cook-ing-checkbox"
-                                type="checkbox"
-                                {checked}
-                                aria-label={`${checked ? 'Uncheck' : 'Check'} ${row.name}`}
-                                onchange={() => model.callbacks.onIngredientToggle(row.name)}
-                            />
+                            <label class="cook-ing-checkbox-hit">
+                                <input
+                                    id={inputId}
+                                    class="cook-ing-checkbox"
+                                    type="checkbox"
+                                    {checked}
+                                    aria-label={`${checked ? 'Uncheck' : 'Check'} ${row.name}`}
+                                    onchange={() => model.callbacks.onIngredientToggle(row.name)}
+                                />
+                            </label>
                         {:else}
                             <span class="cook-ing-checkbox" aria-hidden="true"></span>
                         {/if}

--- a/src/ui/components/MethodSteps.svelte
+++ b/src/ui/components/MethodSteps.svelte
@@ -71,6 +71,8 @@
                                 <img
                                     src={model.host.getResourcePath(image)}
                                     alt={`Step ${step.globalIndex + 1}`}
+                                    loading="lazy"
+                                    decoding="async"
                                 />
                             </figure>
                         {/if}

--- a/src/ui/components/TimerButton.svelte
+++ b/src/ui/components/TimerButton.svelte
@@ -29,6 +29,7 @@
     let selectorReady = $state(false);
     let selectedSeconds = $state(0);
     let popoverLeft = $state(0);
+    let pendingPointerStart: number | undefined;
     let status = $derived(snapshot?.status ?? 'idle');
     let isRange = $derived(duration.minimumSeconds !== duration.maximumSeconds);
     let sliderStep = $derived(timerRangeStep(duration));
@@ -65,6 +66,7 @@
         window.addEventListener('scroll', handleViewportChange, true);
 
         return () => {
+            if (pendingPointerStart !== undefined) window.clearTimeout(pendingPointerStart);
             unsubscribe();
             document.removeEventListener('pointerdown', handleOutsidePointer, true);
             document.removeEventListener('keydown', handleKeydown);
@@ -92,15 +94,28 @@
             if (!selectorOpen) return;
             positionPopover();
             selectorReady = true;
-            sliderElement?.focus();
+            focusWithoutScrolling(sliderElement);
         });
     }
 
     function closeSelector(restoreFocus: boolean): void {
         if (!selectorOpen) return;
+        if (pendingPointerStart !== undefined) {
+            window.clearTimeout(pendingPointerStart);
+            pendingPointerStart = undefined;
+        }
         selectorOpen = false;
         selectorReady = false;
-        if (restoreFocus) void tick().then(() => buttonElement?.focus());
+        if (restoreFocus) void tick().then(() => focusWithoutScrolling(buttonElement));
+    }
+
+    function focusWithoutScrolling(element?: HTMLElement): void {
+        if (!element) return;
+        try {
+            element.focus({ preventScroll: true });
+        } catch {
+            element.focus();
+        }
     }
 
     function positionPopover(): void {
@@ -137,6 +152,21 @@
         startSelected();
     }
 
+    function handleSliderPointerUp(event: PointerEvent): void {
+        const slider = event.currentTarget as HTMLInputElement;
+        if (slider.hasPointerCapture?.(event.pointerId)) {
+            slider.releasePointerCapture(event.pointerId);
+        }
+
+        // Android WebView can retain the range input's implicit pointer capture
+        // when the input is removed during its pointerup handler, blocking later
+        // scroll gestures. Let pointer teardown finish before closing the selector.
+        pendingPointerStart = window.setTimeout(() => {
+            pendingPointerStart = undefined;
+            startSelected();
+        }, 0);
+    }
+
     function closeFromButton(event: MouseEvent): void {
         event.stopPropagation();
         closeSelector(true);
@@ -146,7 +176,7 @@
         event.stopPropagation();
         closeSelector(false);
         controller.reset(timerKey);
-        void tick().then(() => buttonElement?.focus());
+        void tick().then(() => focusWithoutScrolling(buttonElement));
     }
 
 </script>
@@ -175,7 +205,7 @@
             {#if status !== 'running' && status !== 'paused'}
                 <span class="cook-timer-icon" aria-hidden="true">⏱</span>
             {/if}
-            <span class="cook-amt amount" aria-live="polite">{displayTime}</span>
+            <span class="cook-amt amount">{displayTime}</span>
             {#if label}<span class="cook-timer-name">{label}</span>{/if}
         </button>
     </span>
@@ -191,7 +221,7 @@
             style={`left: ${popoverLeft}px;`}
         >
             <span class="cook-timer-range-header">
-                <span class="cook-timer-range-value" aria-live="polite">{formatTime(selectedSeconds)}</span>
+                <span class="cook-timer-range-value">{formatTime(selectedSeconds)}</span>
                 <button
                     type="button"
                     class="cook-timer-range-close"
@@ -211,7 +241,7 @@
                 aria-valuetext={formatTime(selectedSeconds)}
                 aria-describedby={sliderHelpId}
                 oninput={updateSelection}
-                onpointerup={startSelected}
+                onpointerup={handleSliderPointerUp}
                 onkeydown={handleSliderKeydown}
             />
             <span class="cook-timer-range-bounds" aria-hidden="true">


### PR DESCRIPTION
## Summary

- fix Android scrolling becoming locked after starting a time-range timer
- harden shared recipe controls for iOS and Android WebViews with coarse-pointer hit areas, touch feedback, WebKit appearance resets, and scroll-safe focus
- preserve vertical scrolling over the horizontal timer slider and avoid continuous VoiceOver/TalkBack announcements
- prevent mobile pane overflow, lazy-load step images, and document mobile WebView rules in `AGENTS.md`

## Root cause

The range input was removed synchronously from its `pointerup` handler when the selected timer started. Mobile browsers can apply implicit pointer capture to range controls, and Android WebView could retain that gesture state when the target disappeared before pointer cleanup completed. The page would still accept taps, but subsequent scrolling stopped.

The timer now explicitly releases capture when present and defers selector teardown until the next task. Regression coverage verifies that ordering.

## User impact

Range timers no longer leave Android recipe views unable to scroll. Touch controls also receive mobile-sized hit areas and platform-appropriate feedback, while timer updates no longer flood screen-reader live regions.

## Validation

- `npm test` — 17 files, 99 tests passed
- `npm run build` — production bundle completed successfully
- `main.js` and `styles.css` generated successfully