### PR TITLE
fix: reveal mobile caret after keyboard resize

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -18,7 +18,7 @@ import CookViewRoot from './ui/CookViewRoot.svelte';
 import { ObsidianRecipeHost } from './ui/ObsidianRecipeHost';
 import { createUiInstanceId } from './ui/instanceIds';
 import type { CookViewMode, RecipeRenderModel } from './ui/types';
-import { availableViewportHeight } from './utils/mobileViewport';
+import { availableViewportHeight, caretScrollDelta } from './utils/mobileViewport';
 
 // Use Obsidian's semantic colors so highlighting follows the active theme
 // without giving CodeMirror an independent editor surface.
@@ -191,10 +191,38 @@ export class CookView extends TextFileView {
             visualViewport,
         );
         const value = `${height}px`;
-        if (this.sourceEl.style.getPropertyValue('--cook-source-viewport-height') === value) return;
+        if (this.sourceEl.style.getPropertyValue('--cook-source-viewport-height') !== value) {
+            this.sourceEl.style.setProperty('--cook-source-viewport-height', value);
+        }
 
-        this.sourceEl.style.setProperty('--cook-source-viewport-height', value);
-        this.editorView.requestMeasure();
+        // CodeMirror scrolls the selection before iOS finishes opening the
+        // keyboard. Once the visual viewport settles, its old scroll position
+        // can leave the caret below the newly shortened editor. Measure after
+        // applying the height and correct the editor's own scroll container.
+        this.editorView.requestMeasure({
+            read: (view) => {
+                if (!view.hasFocus) return 0;
+                const caret = view.coordsAtPos(view.state.selection.main.head);
+                if (!caret) return 0;
+
+                const sourceBounds = this.sourceEl.getBoundingClientRect();
+                const viewportTop = Math.max(sourceBounds.top, visualViewport.offsetTop);
+                const viewportBottom = Math.min(
+                    sourceBounds.bottom,
+                    visualViewport.offsetTop + visualViewport.height,
+                );
+                return caretScrollDelta(
+                    caret.top,
+                    caret.bottom,
+                    viewportTop,
+                    viewportBottom,
+                );
+            },
+            write: (delta, view) => {
+                if (delta !== 0) view.scrollDOM.scrollTop += delta;
+            },
+            key: 'cook-mobile-caret',
+        });
     }
 
     setViewMode(mode: CookViewMode) {

--- a/src/utils/mobileViewport.test.ts
+++ b/src/utils/mobileViewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { availableViewportHeight } from './mobileViewport';
+import { availableViewportHeight, caretScrollDelta } from './mobileViewport';
 
 describe('availableViewportHeight', () => {
     it('uses the container height when the whole editor is visible', () => {
@@ -16,5 +16,19 @@ describe('availableViewportHeight', () => {
 
     it('never returns a negative height', () => {
         expect(availableViewportHeight(600, 600, { height: 500, offsetTop: 0 })).toBe(0);
+    });
+});
+
+describe('caretScrollDelta', () => {
+    it('moves a caret hidden below the visual viewport into view', () => {
+        expect(caretScrollDelta(823, 837, 64, 498)).toBe(347);
+    });
+
+    it('moves a caret hidden above the visual viewport into view', () => {
+        expect(caretScrollDelta(100, 114, 120, 500)).toBe(-28);
+    });
+
+    it('leaves a visible caret in place', () => {
+        expect(caretScrollDelta(200, 214, 120, 500)).toBe(0);
     });
 });

--- a/src/utils/mobileViewport.ts
+++ b/src/utils/mobileViewport.ts
@@ -11,3 +11,19 @@ export function availableViewportHeight(
     const viewportBottom = viewport.offsetTop + viewport.height;
     return Math.max(0, Math.min(containerHeight, viewportBottom - elementTop));
 }
+
+export function caretScrollDelta(
+    caretTop: number,
+    caretBottom: number,
+    viewportTop: number,
+    viewportBottom: number,
+    padding = 8,
+): number {
+    if (caretBottom > viewportBottom - padding) {
+        return caretBottom - viewportBottom + padding;
+    }
+    if (caretTop < viewportTop + padding) {
+        return caretTop - viewportTop - padding;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- after the mobile viewport resize is laid out, reveal the focused caret in CodeMirror's own scroll container
- calculate only the minimum scroll correction needed to put the caret back inside the visible editor
- add regression coverage for caret positions below, above, and inside the visual viewport

## Why

The visual-viewport fix in #127 correctly resizes the editor when a mobile keyboard opens, but resizing alone is insufficient. CodeMirror has already scrolled the selection before iOS finishes opening the keyboard, so its old scroll position can leave the caret behind the keyboard after the editor becomes shorter.

This change first constrains the editor to the settled visual viewport, then uses CodeMirror's measured DOM phase to calculate and apply the minimum scroll correction needed to reveal the caret.

## Validation

- iOS 26.5 Simulator, iPhone 17 Pro, software keyboard enabled
- WKWebView harness using the plugin's pinned CodeMirror packages and source-editor layout
- reproduced failure: layout viewport `874px`, visual viewport `498px`, editor `64..498px`, caret still hidden at `823..837px`
- verified fix: same viewport and editor geometry, caret moved to `479..493px` above the keyboard
- `npm test` — 18 test files, 107 tests passed
- `npm run build` — production bundle completed successfully
- `git diff --check` — passed

The simulator harness validates the WebKit/CodeMirror keyboard interaction directly. The Obsidian iOS binary itself is not available for installation in a standard Xcode simulator, so a physical-device confirmation in Obsidian remains recommended before release.
