### PR TITLE
chore: use Obsidian CodeMirror runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "howler": "^2.2.4",
         "jsdom": "^30.0.1",
         "mathjs": "^15.2.0",
-        "obsidian": "1.13.1",
+        "obsidian": "latest",
         "rollup": "^4.62.4",
         "rollup-plugin-svelte": "^7.2.3",
         "sass": "^1.102.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "howler": "^2.2.4",
     "jsdom": "^30.0.1",
     "mathjs": "^15.2.0",
-    "obsidian": "1.13.1",
+    "obsidian": "latest",
     "rollup": "^4.62.4",
     "rollup-plugin-svelte": "^7.2.3",
     "sass": "^1.102.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -88,7 +88,23 @@ export default {
     banner,
     inlineDynamicImports: true
   },
-  external: ['obsidian', 'codemirror'],
+  // Obsidian exposes these modules at runtime. Keeping them external avoids
+  // loading a second CodeMirror/Lezer instance inside the plugin bundle.
+  external: [
+    'obsidian',
+    'codemirror',
+    '@codemirror/autocomplete',
+    '@codemirror/collab',
+    '@codemirror/commands',
+    '@codemirror/language',
+    '@codemirror/lint',
+    '@codemirror/search',
+    '@codemirror/state',
+    '@codemirror/view',
+    '@lezer/common',
+    '@lezer/highlight',
+    '@lezer/lr'
+  ],
   plugins: [
     // WASM plugin must come first to properly handle wasm imports
     wasm({


### PR DESCRIPTION
## Summary

- externalize the CodeMirror 6 and Lezer modules supplied by Obsidian, matching the official sample-plugin build configuration
- follow the official sample's `obsidian: latest` development dependency policy while retaining the reproducible lockfile
- remove the second bundled CodeMirror/Lezer runtime from `main.js`

## Why

The Rollup configuration only marked the legacy bare `codemirror` package as external. Imports such as `@codemirror/view`, `@codemirror/state`, and `@lezer/highlight` were therefore bundled into the plugin even though Obsidian exposes those modules at runtime.

Using Obsidian's modules keeps extensions and editor state on one CodeMirror instance, lets the plugin receive the CodeMirror version shipped with the installed Obsidian release, and avoids carrying an unnecessary second runtime.

The latest API currently published to npm remains Obsidian 1.13.1, so the lockfile still resolves its compatible View 6.38.6 / State 6.5.0 development types. The unreleased 1.13.2 API snapshot is deliberately not pinned from GitHub.

## Validation

- `npm ci` — clean reproducible install
- `npm ls @codemirror/state @codemirror/view --all` — one compatible View/State graph
- `npm test` — 18 test files, 104 tests passed
- `npm run build` — production bundle completed successfully
- generated `main.js` imports the five used host modules: View, State, Language, Commands, and Lezer Highlight
- generated bundle size: 7,160,768 bytes before; 5,446,711 bytes after (1,714,057 bytes / 23.9% smaller)
- `git diff --check` — passed
