### PR TITLE
fix: fill Android editor viewport

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,8 +22,9 @@
 
   .cook-source-view-full {
     display: flex;
-    flex: 1 1 auto;
+    flex: 1 1 0;
     flex-direction: column;
+    height: 100%;
     min-height: 0;
     width: 100%;
     box-sizing: border-box;
@@ -194,8 +195,9 @@
 
   // CodeMirror 6 styles
   .cm-editor {
-    flex: 1 1 auto;
-    height: auto;
+    // Match Obsidian's native Markdown editor. A zero flex basis gives
+    // CodeMirror's 100%-height scroller a definite viewport on Android.
+    flex: 1 1 0;
     min-height: 0;
     font-family: var(--font-monospace);
     background-color: transparent;


### PR DESCRIPTION
## Summary

- give the Cooklang source host a definite full height
- use a zero flex basis for the source host and CodeMirror editor
- preserve CodeMirror's scroller as the only source-editor scroll container

## Why

Follow-up Android device testing after #132 showed that the outer editor reaches the software keyboard correctly, but CodeMirror renders only part of that area and leaves a large black region inside the editor.

The debug recording shows the scrollbar ending with the rendered text while the editor bounds continue to the keyboard. The remaining mismatch was the flex basis: the custom editor used `flex: 1 1 auto`, while Obsidian's native Markdown editor uses a zero basis. With an intrinsic basis, Android WebView can resolve CodeMirror's `height: 100%` scroller against a shorter content-derived height even though the outer editor grows correctly.

This change makes the source flex chain definite and matches Obsidian's native editor sizing behavior.

## Validation

- `npm test` — 17 files, 100 tests passed
- `npm run build` — production bundle generated successfully
- `git diff --check`

Physical Android verification is still recommended because the failure depends on WebView keyboard-resize layout.
