### PR TITLE
fix: improve mobile editor and timer behavior

### DIFF
--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -2,7 +2,7 @@ import type { CooklangRecipe } from '@cooklang/cooklang';
 import {TextFileView, WorkspaceLeaf, ViewStateResult} from 'obsidian'
 import {CooklangSettings} from './settings';
 import {EditorView, keymap, highlightActiveLine, lineNumbers} from "@codemirror/view"
-import {EditorState, Extension} from "@codemirror/state"
+import {Annotation, EditorState, Extension} from "@codemirror/state"
 import {syntaxHighlighting, HighlightStyle} from "@codemirror/language"
 import {defaultKeymap} from "@codemirror/commands"
 import {cooklang} from './mode/cook/cook'
@@ -30,6 +30,10 @@ const cooklangHighlightStyle = HighlightStyle.define([
     {tag: t.unit, color: 'var(--color-orange)'},        // Units
 ]);
 
+// File loads and view cleanup also replace the CodeMirror document. Mark those
+// transactions so only editor-originated changes schedule an Obsidian save.
+const skipSave = Annotation.define<boolean>();
+
 // This is the custom view
 export class CookView extends TextFileView {
     settings: CooklangSettings;
@@ -45,6 +49,8 @@ export class CookView extends TextFileView {
     private host: ObsidianRecipeHost;
     private instanceId: string;
     private editorLineWrap: boolean;
+    private viewportMeasureFrame: number | null = null;
+    private removeViewportListeners: (() => void) | null = null;
     data: string = '';
     checkedIngredients: Set<string> = new Set();
     scale: number = 1;
@@ -99,6 +105,8 @@ export class CookView extends TextFileView {
     async onload() {
         super.onload();
 
+        this.initializeViewportRemeasure();
+
         // Wait for parser to be ready
         await this.parserReady;
         if (this.currentView === 'preview') this.renderPreview();
@@ -120,6 +128,15 @@ export class CookView extends TextFileView {
             highlightActiveLine(),
             cooklang, // Our custom Cooklang language support
             syntaxHighlighting(cooklangHighlightStyle),
+            EditorView.updateListener.of((update) => {
+                if (!update.docChanged) return;
+
+                this.data = update.state.doc.toString();
+                const shouldSave = update.transactions.some((transaction) =>
+                    transaction.docChanged && transaction.annotation(skipSave) !== true
+                );
+                if (shouldSave) this.requestSave();
+            }),
             keymap.of([
                 ...defaultKeymap,  // Include all default editing commands (Enter, Backspace, etc.)
                 {
@@ -147,12 +164,43 @@ export class CookView extends TextFileView {
         });
     }
 
+    private initializeViewportRemeasure(): void {
+        const editorWindow = this.sourceEl.ownerDocument.defaultView ?? window;
+        const visualViewport = editorWindow.visualViewport;
+        const handleViewportChange = () => this.queueEditorMeasure();
+
+        editorWindow.addEventListener('resize', handleViewportChange);
+        visualViewport?.addEventListener('resize', handleViewportChange);
+        visualViewport?.addEventListener('scroll', handleViewportChange);
+        this.sourceEl.addEventListener('focusin', handleViewportChange);
+
+        this.removeViewportListeners = () => {
+            editorWindow.removeEventListener('resize', handleViewportChange);
+            visualViewport?.removeEventListener('resize', handleViewportChange);
+            visualViewport?.removeEventListener('scroll', handleViewportChange);
+            this.sourceEl.removeEventListener('focusin', handleViewportChange);
+        };
+    }
+
+    private queueEditorMeasure(): void {
+        if (this.currentView !== 'source') return;
+
+        const editorWindow = this.sourceEl.ownerDocument.defaultView ?? window;
+        if (this.viewportMeasureFrame !== null) {
+            editorWindow.cancelAnimationFrame(this.viewportMeasureFrame);
+        }
+        this.viewportMeasureFrame = editorWindow.requestAnimationFrame(() => {
+            this.viewportMeasureFrame = null;
+            if (this.currentView === 'source') this.editorView.requestMeasure();
+        });
+    }
+
     setViewMode(mode: CookViewMode) {
         this.currentView = mode;
         this.modeStore.set(mode);
         if (mode === 'preview') this.renderPreview();
         else {
-            this.editorView.requestMeasure();
+            this.queueEditorMeasure();
         }
     }
 
@@ -161,6 +209,13 @@ export class CookView extends TextFileView {
     }
 
     onunload() {
+        this.removeViewportListeners?.();
+        this.removeViewportListeners = null;
+        if (this.viewportMeasureFrame !== null) {
+            const editorWindow = this.sourceEl.ownerDocument.defaultView ?? window;
+            editorWindow.cancelAnimationFrame(this.viewportMeasureFrame);
+            this.viewportMeasureFrame = null;
+        }
         if (this.editorView) {
             this.editorView.destroy();
         }
@@ -225,7 +280,8 @@ export class CookView extends TextFileView {
                     from: 0,
                     to: this.editorView.state.doc.length,
                     insert: data
-                }
+                },
+                annotations: skipSave.of(true),
             });
         } else {
             this.editorView.dispatch({
@@ -233,7 +289,8 @@ export class CookView extends TextFileView {
                     from: 0,
                     to: this.editorView.state.doc.length,
                     insert: data
-                }
+                },
+                annotations: skipSave.of(true),
             });
         }
 
@@ -254,7 +311,8 @@ export class CookView extends TextFileView {
                 from: 0,
                 to: this.editorView.state.doc.length,
                 insert: ''
-            }
+            },
+            annotations: skipSave.of(true),
         });
         this.data = '';
         this.scale = 1;
@@ -305,7 +363,7 @@ export class CookView extends TextFileView {
 
     // when the view is resized, refresh CodeMirror
     onResize() {
-        this.editorView.requestMeasure();
+        this.queueEditorMeasure();
     }
 
     getIcon() {

--- a/src/services/TimerService.test.ts
+++ b/src/services/TimerService.test.ts
@@ -94,4 +94,41 @@ describe('TimerService timer controller', () => {
 
         service.dispose();
     });
+
+    it('uses elapsed wall time when interval callbacks were suspended', () => {
+        vi.setSystemTime(new Date('2026-08-28T10:00:00Z'));
+        const service = new TimerService(
+            { timersTick: false, timersRing: false } as any,
+            { tickSoundUrl: 'tick.mp3', alarmSoundUrl: 'alarm.mp3' },
+        );
+
+        service.toggle('timer', 10, 'rest');
+
+        // Moving the wall clock simulates a backgrounded WebView that did not
+        // get a chance to run its once-per-second interval callbacks.
+        vi.setSystemTime(new Date('2026-08-28T10:00:04Z'));
+        vi.advanceTimersByTime(1000);
+
+        expect(service.getSnapshot('timer')).toMatchObject({ remaining: 5, status: 'running' });
+
+        service.dispose();
+    });
+
+    it('reconciles elapsed background time before pausing', () => {
+        vi.setSystemTime(new Date('2026-08-28T10:00:00Z'));
+        const service = new TimerService(
+            { timersTick: false, timersRing: false } as any,
+            { tickSoundUrl: 'tick.mp3', alarmSoundUrl: 'alarm.mp3' },
+        );
+
+        service.toggle('timer', 10, 'rest');
+        vi.setSystemTime(new Date('2026-08-28T10:00:04Z'));
+        service.toggle('timer', 10, 'rest');
+
+        expect(service.getSnapshot('timer')).toMatchObject({ remaining: 6, status: 'paused' });
+        vi.advanceTimersByTime(2000);
+        expect(service.getSnapshot('timer')).toMatchObject({ remaining: 6, status: 'paused' });
+
+        service.dispose();
+    });
 });

--- a/src/services/TimerService.ts
+++ b/src/services/TimerService.ts
@@ -19,6 +19,7 @@ export interface Timer {
     remaining: number;
     label: string;
     isRunning: boolean;
+    endsAt?: number;
     intervalId?: number;
 }
 
@@ -52,6 +53,10 @@ export class TimerService {
     private listeners: Map<string, Set<(snapshot: TimerSnapshot | null) => void>> = new Map();
     private tickSound: Howl;
     private alarmSound: Howl;
+    private readonly handleVisibilityChange = (): void => {
+        if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+        for (const timer of this.timers.values()) this.updateRunningTimer(timer);
+    };
 
     /**
      * Create a new TimerService
@@ -68,6 +73,10 @@ export class TimerService {
             src: [config.alarmSoundUrl],
             volume: config.alarmVolume ?? 0.3
         });
+
+        if (typeof document !== 'undefined') {
+            document.addEventListener('visibilitychange', this.handleVisibilityChange);
+        }
     }
 
     public toggle(key: string, seconds: number, label: string): void {
@@ -134,23 +143,14 @@ export class TimerService {
             duration: seconds,
             remaining: seconds,
             label: name,
-            isRunning: true
+            isRunning: true,
+            endsAt: Date.now() + seconds * 1000,
         };
 
         // Play tick sound when timer starts
         this.playTick();
 
-        const intervalId = window.setInterval(() => {
-            timer.remaining = Math.max(0, timer.remaining - 1);
-            onTick(timer.remaining);
-            this.notifyTimer(timer.id);
-
-            if (timer.remaining <= 0) {
-                this.stopTimer(timer.id);
-                this.playAlarm();
-                new Notice(`Timer "${name}" has finished!`, 5000);
-            }
-        }, 1000);
+        const intervalId = window.setInterval(() => this.updateRunningTimer(timer, onTick), 1000);
 
         timer.intervalId = intervalId;
         this.timers.set(timer.id, timer);
@@ -170,12 +170,11 @@ export class TimerService {
      */
     public stopTimer(timerId: string): void {
         const timer = this.timers.get(timerId);
-        if (timer && timer.intervalId !== undefined) {
-            clearInterval(timer.intervalId);
-            timer.isRunning = false;
-            timer.intervalId = undefined;
-            this.notifyTimer(timerId);
-        }
+        if (!timer) return;
+        this.clearTimerInterval(timer);
+        timer.isRunning = false;
+        timer.endsAt = undefined;
+        this.notifyTimer(timerId);
     }
 
     /**
@@ -184,12 +183,17 @@ export class TimerService {
      */
     public pauseTimer(timerId: string): void {
         const timer = this.timers.get(timerId);
-        if (timer && timer.isRunning && timer.intervalId !== undefined) {
-            clearInterval(timer.intervalId);
-            timer.isRunning = false;
-            timer.intervalId = undefined;
-            this.notifyTimer(timerId);
-        }
+        if (!timer?.isRunning) return;
+
+        // Reconcile against wall time before pausing. A backgrounded mobile
+        // WebView may not have delivered any interval callbacks in the meantime.
+        this.updateRunningTimer(timer);
+        if (!timer.isRunning) return;
+
+        this.clearTimerInterval(timer);
+        timer.isRunning = false;
+        timer.endsAt = undefined;
+        this.notifyTimer(timerId);
     }
 
     /**
@@ -201,19 +205,8 @@ export class TimerService {
         const timer = this.timers.get(timerId);
         if (!timer || timer.isRunning) return;
 
-        const intervalId = window.setInterval(() => {
-            if (timer.remaining > 0) {
-                timer.remaining--;
-                onTick(timer.remaining);
-                this.notifyTimer(timerId);
-
-                if (timer.remaining <= 0) {
-                    this.stopTimer(timerId);
-                    this.playAlarm();
-                    new Notice(`Timer "${timer.label}" has finished!`, 5000);
-                }
-            }
-        }, 1000);
+        timer.endsAt = Date.now() + timer.remaining * 1000;
+        const intervalId = window.setInterval(() => this.updateRunningTimer(timer, onTick), 1000);
 
         timer.intervalId = intervalId;
         timer.isRunning = true;
@@ -230,6 +223,7 @@ export class TimerService {
             this.stopTimer(timerId);
             timer.remaining = timer.duration;
             timer.isRunning = false;
+            timer.endsAt = undefined;
             this.notifyTimer(timerId);
         }
     }
@@ -275,6 +269,10 @@ export class TimerService {
      * Stop all timers and clean up
      */
     public dispose(): void {
+        if (typeof document !== 'undefined') {
+            document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+        }
+
         // Stop all running timers
         for (const timer of this.timers.values()) {
             if (timer.intervalId !== undefined) {
@@ -296,6 +294,30 @@ export class TimerService {
      */
     private generateTimerId(): string {
         return `timer_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    }
+
+    private updateRunningTimer(timer: Timer, onTick: (remaining: number) => void = () => {}): void {
+        if (!timer.isRunning || timer.endsAt === undefined) return;
+
+        timer.remaining = Math.max(0, Math.ceil((timer.endsAt - Date.now()) / 1000));
+        if (timer.remaining <= 0) {
+            this.clearTimerInterval(timer);
+            timer.isRunning = false;
+            timer.endsAt = undefined;
+        }
+
+        onTick(timer.remaining);
+        this.notifyTimer(timer.id);
+
+        if (timer.remaining <= 0) {
+            this.playAlarm();
+            new Notice(`Timer "${timer.label}" has finished!`, 5000);
+        }
+    }
+
+    private clearTimerInterval(timer: Timer): void {
+        if (timer.intervalId !== undefined) clearInterval(timer.intervalId);
+        timer.intervalId = undefined;
     }
 
     private notifyTimer(timerId: string): void {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -375,6 +375,7 @@
   border-radius: 0 8px 8px 0; padding-left: 12px; margin-left: -12px;
 }
 .cook-step.done { opacity: 0.5; }
+.cook-step-trackable { cursor: pointer; }
 .cook-step-n { flex: none; color: var(--text-accent); font-weight: 700; }
 .cook-step-toggle {
   align-self: flex-start; min-width: 28px; min-height: 28px; margin: -4px 0 0 -6px;

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -178,6 +178,42 @@ describe('RecipePreview', () => {
         expect(renderModel.timers?.toggle).not.toHaveBeenCalled();
     });
 
+    it('keeps step tracking available while an inline timer is running', async () => {
+        let timerListener: ((snapshot: TimerSnapshot | null) => void) | undefined;
+        const renderModel = model({
+            timers: {
+                toggle: vi.fn(),
+                reset: vi.fn(),
+                subscribe: (_key, listener) => {
+                    timerListener = listener;
+                    return () => {};
+                },
+            },
+        });
+        render(RecipePreview, { model: renderModel });
+
+        timerListener?.({
+            id: 'timer-id',
+            duration: 120,
+            remaining: 90,
+            label: 'rest',
+            status: 'running',
+        });
+        await screen.findByRole('button', { name: 'Pause rest (1:30)' });
+
+        const step = document.querySelector<HTMLElement>('.cook-step');
+        expect(step).toBeTruthy();
+        if (!step) throw new Error('Expected a rendered recipe step.');
+        await fireEvent.click(step);
+
+        expect(renderModel.callbacks.onStepActivate).toHaveBeenCalledOnce();
+        expect(renderModel.callbacks.onStepActivate).toHaveBeenCalledWith(0);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Pause rest (1:30)' }));
+        expect(renderModel.timers?.toggle).toHaveBeenCalledOnce();
+        expect(renderModel.callbacks.onStepActivate).toHaveBeenCalledOnce();
+    });
+
     it('honors settings that hide optional recipe regions', () => {
         const renderModel = model({
             settings: {

--- a/src/ui/components/MethodSteps.svelte
+++ b/src/ui/components/MethodSteps.svelte
@@ -23,6 +23,20 @@
         if (!model.settings.showImages || !model.file) return null;
         return getStepImageFor(step.globalIndex + 1, model.file.basename, allImages);
     }
+
+    function trackStep(node: HTMLElement, index: number): { update: (nextIndex: number) => void; destroy: () => void } {
+        let stepIndex = index;
+        const activate = (event: MouseEvent): void => {
+            if (!model.settings.enableStepTracking || !(event.target instanceof Element)) return;
+            if (event.target.closest('button, a, input, label, select, textarea')) return;
+            model.callbacks.onStepActivate(stepIndex);
+        };
+        node.addEventListener('click', activate);
+        return {
+            update: (nextIndex: number) => { stepIndex = nextIndex; },
+            destroy: () => node.removeEventListener('click', activate),
+        };
+    }
 </script>
 
 <section class="cook-steps" id="cook-steps">
@@ -43,7 +57,13 @@
                 {@const current = tracking && model.state.currentStep === step.globalIndex}
                 {@const done = tracking && model.state.currentStep > step.globalIndex}
                 {@const image = stepImage(step)}
-                <article class:cur={current} class:done={done} class="cook-step">
+                <article
+                    class:cur={current}
+                    class:done={done}
+                    class:cook-step-trackable={tracking}
+                    class="cook-step"
+                    use:trackStep={step.globalIndex}
+                >
                     {#if tracking}
                         <button
                             type="button"


### PR DESCRIPTION
## Summary

- remeasure CodeMirror after mobile visual viewport changes so the editor remains correctly sized around the software keyboard
- derive running timers from an absolute deadline so throttled or suspended interval callbacks do not lose elapsed time
- reconcile timers when Obsidian becomes visible and before pause/resume actions
- keep recipe steps selectable while a timer is active without letting nested timer or reference controls toggle the step

## Validation

- `npm test` — 17 files, 103 tests passed
- `npm run build` — production bundle generated successfully
- `git diff --check`

## Mobile note

The countdown remains accurate while the WebView is backgrounded. If the OS fully suspends Obsidian, JavaScript-based sound and the in-app Notice are delivered when the WebView resumes; the public Obsidian API does not expose a native scheduled-notification facility.

Physical iOS and Android device verification was not available in this environment.