### PR TITLE
fix: restore editor syntax highlighting

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -88,23 +88,11 @@ export default {
     banner,
     inlineDynamicImports: true
   },
-  // Obsidian exposes these modules at runtime. Keeping them external avoids
-  // loading a second CodeMirror/Lezer instance inside the plugin bundle.
-  external: [
-    'obsidian',
-    'codemirror',
-    '@codemirror/autocomplete',
-    '@codemirror/collab',
-    '@codemirror/commands',
-    '@codemirror/language',
-    '@codemirror/lint',
-    '@codemirror/search',
-    '@codemirror/state',
-    '@codemirror/view',
-    '@lezer/common',
-    '@lezer/highlight',
-    '@lezer/lr'
-  ],
+  // CookView owns a standalone CodeMirror editor, so keep its CodeMirror 6 and
+  // Lezer graph together in this bundle. Obsidian's runtime modules are an
+  // internal implementation detail and can otherwise split highlighting tags
+  // across incompatible module instances.
+  external: ['obsidian', 'codemirror'],
   plugins: [
     // WASM plugin must come first to properly handle wasm imports
     wasm({

--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -3,10 +3,9 @@ import {TextFileView, WorkspaceLeaf, ViewStateResult} from 'obsidian'
 import {CooklangSettings} from './settings';
 import {EditorView, keymap, highlightActiveLine, lineNumbers} from "@codemirror/view"
 import {EditorState, Extension} from "@codemirror/state"
-import {syntaxHighlighting, HighlightStyle} from "@codemirror/language"
+import {syntaxHighlighting} from "@codemirror/language"
 import {defaultKeymap} from "@codemirror/commands"
-import {cooklang} from './mode/cook/cook'
-import {tags as t} from "@lezer/highlight"
+import {cooklang, cooklangHighlighter} from './mode/cook/cook'
 import { parserService } from './services/ParserService';
 import { TimerService } from './services/TimerService';
 import { parseServingsValue, computeScale, deriveServingsState } from './utils/scaling';
@@ -18,17 +17,6 @@ import CookViewRoot from './ui/CookViewRoot.svelte';
 import { ObsidianRecipeHost } from './ui/ObsidianRecipeHost';
 import { createUiInstanceId } from './ui/instanceIds';
 import type { CookViewMode, RecipeRenderModel } from './ui/types';
-
-// Use Obsidian's semantic colors so highlighting follows the active theme
-// without giving CodeMirror an independent editor surface.
-const cooklangHighlightStyle = HighlightStyle.define([
-    {tag: t.variableName, color: 'var(--text-accent)'}, // Ingredients (@flour)
-    {tag: t.keyword, color: 'var(--color-green)'},      // Cookware (#bowl)
-    {tag: t.number, color: 'var(--color-pink)'},        // Timers (~)
-    {tag: t.comment, color: 'var(--text-faint)'},       // Comments
-    {tag: t.meta, color: 'var(--text-muted)'},          // Metadata and frontmatter
-    {tag: t.unit, color: 'var(--color-orange)'},        // Units
-]);
 
 // This is the custom view
 export class CookView extends TextFileView {
@@ -119,7 +107,7 @@ export class CookView extends TextFileView {
             lineNumbers(),
             highlightActiveLine(),
             cooklang, // Our custom Cooklang language support
-            syntaxHighlighting(cooklangHighlightStyle),
+            syntaxHighlighting(cooklangHighlighter),
             keymap.of([
                 ...defaultKeymap,  // Include all default editing commands (Enter, Backspace, etc.)
                 {

--- a/src/mode/cook/cook.test.ts
+++ b/src/mode/cook/cook.test.ts
@@ -1,9 +1,9 @@
 import { EditorState } from '@codemirror/state';
 import { ensureSyntaxTree } from '@codemirror/language';
-import { classHighlighter, highlightTree } from '@lezer/highlight';
+import { classHighlighter, type Highlighter, highlightTree } from '@lezer/highlight';
 import { describe, expect, it } from 'vitest';
 
-import { cooklang } from './cook';
+import { cooklang, cooklangHighlighter } from './cook';
 
 type HighlightRange = {
     from: number;
@@ -11,14 +11,14 @@ type HighlightRange = {
     classes: string;
 };
 
-function highlightedRanges(doc: string): HighlightRange[] {
+function highlightedRanges(doc: string, highlighter: Highlighter = classHighlighter): HighlightRange[] {
     const state = EditorState.create({ doc, extensions: [cooklang] });
     const tree = ensureSyntaxTree(state, doc.length, 1_000);
 
     expect(tree).not.toBeNull();
 
     const ranges: HighlightRange[] = [];
-    highlightTree(tree!, classHighlighter, (from, to, classes) => {
+    highlightTree(tree!, highlighter, (from, to, classes) => {
         ranges.push({ from, to, classes });
     });
     return ranges;
@@ -49,6 +49,31 @@ describe('Cooklang syntax highlighting', () => {
             'tok-keyword',
             'tok-variableName',
             'tok-number',
+        ]);
+    });
+
+    it('assigns stable plugin classes to Cooklang tokens', () => {
+        const doc = [
+            '---',
+            'servings: 2',
+            '---',
+            'Add @flour{200%g} to a #bowl and wait for ~rest{5%min}.',
+            '-- This is a comment.',
+        ].join('\n');
+
+        expect(highlightedRanges(doc, cooklangHighlighter).map(({ from, to, classes }) => ({
+            text: doc.slice(from, to),
+            classes,
+        }))).toEqual([
+            { text: '---', classes: 'cook-token-meta' },
+            { text: 'servings: 2', classes: 'cook-token-meta' },
+            { text: '---', classes: 'cook-token-meta' },
+            { text: '@flour', classes: 'cook-token-ingredient' },
+            { text: 'g', classes: 'cook-token-unit' },
+            { text: '#bowl', classes: 'cook-token-cookware' },
+            { text: '~rest', classes: 'cook-token-timer' },
+            { text: 'min', classes: 'cook-token-unit' },
+            { text: '-- This is a comment.', classes: 'cook-token-comment' },
         ]);
     });
 });

--- a/src/mode/cook/cook.ts
+++ b/src/mode/cook/cook.ts
@@ -1,4 +1,14 @@
 import { StreamLanguage } from "@codemirror/language"
+import { tagHighlighter, tags as t } from "@lezer/highlight"
+
+export const cooklangHighlighter = tagHighlighter([
+  {tag: t.variableName, class: "cook-token-ingredient"},
+  {tag: t.keyword, class: "cook-token-cookware"},
+  {tag: t.number, class: "cook-token-timer"},
+  {tag: t.comment, class: "cook-token-comment"},
+  {tag: t.meta, class: "cook-token-meta"},
+  {tag: t.unit, class: "cook-token-unit"}
+])
 
 // Define the Cooklang language
 export const cooklang = StreamLanguage.define({

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -220,6 +220,15 @@
   .cm-line {
     padding: 0 4px;
   }
+
+  // Stable token classes keep Cooklang colors under the plugin stylesheet's
+  // scope instead of relying on CodeMirror's generated style-module classes.
+  .cook-token-ingredient { color: var(--text-accent); }
+  .cook-token-cookware { color: var(--color-green); }
+  .cook-token-timer { color: var(--color-pink); }
+  .cook-token-comment { color: var(--text-faint); }
+  .cook-token-meta { color: var(--text-muted); }
+  .cook-token-unit { color: var(--color-orange); }
 }
 
 // Match Obsidian's native mobile editor behavior in WKWebView. This keeps the


### PR DESCRIPTION
## Summary

- replace generated CodeMirror highlight classes with stable, plugin-prefixed token classes
- style Cooklang tokens through the plugin stylesheet using Obsidian semantic colors
- keep the standalone CookView CodeMirror and Lezer dependency graph bundled together
- add regression coverage for metadata, ingredients, cookware, timers, units, and comments

## Why

Editor syntax colors stopped rendering after the CodeMirror and Lezer modules were externalized to Obsidian runtime modules. CookView owns a standalone editor, and its highlighting should not depend on Obsidian internal module instances or dynamically generated style-module classes.

## Validation

- npm test — 17 test files, 101 tests passed
- npm run build — production bundle completed successfully
- generated main.js has no runtime imports for CodeMirror or Lezer modules
- force-reloaded Obsidian 1.13.7 and verified syntax colors in the dark theme