### PR TITLE
fix: show shorthand preparations in preview

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -330,7 +330,7 @@
 /* Ingredient checklist */
 .cook-ing-list { list-style: none; margin: 0; padding: 0; }
 .cook-ing {
-  display: flex; align-items: center; gap: 10px; padding: 7px 0;
+  display: flex; align-items: flex-start; gap: 10px; padding: 7px 0;
   border-bottom: 1px solid var(--background-modifier-border); font-size: 0.92em;
 }
 .cook-ing:last-child { border-bottom: none; }
@@ -339,7 +339,11 @@
   width: 17px; height: 17px; flex: none; border-radius: 5px;
   border: 1.5px solid var(--text-faint); background: transparent; cursor: pointer;
 }
-.cook-ing-checkbox-hit { display: inline-flex; flex: none; }
+.cook-ing-checkbox-hit {
+  display: inline-flex; flex: none; align-items: center; justify-content: center;
+  min-height: 1.6em;
+}
+.cook-ing > .cook-ing-checkbox { margin-block-start: calc((1.6em - 17px) / 2); }
 .cook-ing-checkbox:checked {
   background: var(--interactive-accent); border-color: var(--interactive-accent); position: relative;
 }
@@ -566,12 +570,12 @@
   }
   .cook-stepper { height: 50px; border-radius: 25px; padding: 0; }
   .cook-stepper-btn { width: 48px; height: 48px; }
-  .cook-ing { min-height: 48px; }
+  .cook-ing { min-height: 48px; padding-block: 0; }
   .cook-ing-checkbox-hit {
-    align-items: center; justify-content: center;
-    width: 48px; min-height: 48px; margin-block: -7px;
+    width: 48px; min-height: 48px;
   }
-  .cook-ing-details > summary { min-height: 48px; }
+  .cook-ing-main { min-height: 48px; }
+  .cook-ing > .cook-ing-checkbox { margin-block-start: 15.5px; }
   .cook-step-toggle {
     min-width: 48px; min-height: 48px; margin: -10px 0 -10px -10px;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -347,10 +347,32 @@
   content: '✓'; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
   color: var(--text-on-accent); font-size: 0.7em;
 }
-.cook-ing-name { flex: 1; }
-.cook-ing-name label { cursor: pointer; overflow-wrap: anywhere; }
-.cook-ing.done .cook-ing-name { text-decoration: line-through; color: var(--text-faint); }
+.cook-ing-content { flex: 1; min-width: 0; }
+.cook-ing-main { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.cook-ing-name { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.cook-ing.done .cook-ing-content { text-decoration: line-through; color: var(--text-faint); }
 .cook-ing-qty { color: var(--text-muted); font-variant-numeric: tabular-nums; font-size: 0.85em; }
+.cook-ing-single-prep { color: var(--text-muted); font-size: 0.9em; }
+.cook-ing-details > summary {
+  list-style: none; cursor: pointer;
+}
+.cook-ing-details > summary::-webkit-details-marker { display: none; }
+.cook-ing-disclosure-icon {
+  flex: none; width: 0.55em; height: 0.55em; margin-inline: 1px 3px;
+  border-inline-end: 1.5px solid var(--text-muted);
+  border-block-end: 1.5px solid var(--text-muted);
+  transform: rotate(45deg) translateY(-2px);
+}
+.cook-ing-details[open] .cook-ing-disclosure-icon { transform: rotate(225deg) translate(-1px, -1px); }
+.cook-ing-prep-list {
+  list-style: none; margin: var(--size-2-2, 6px) 0 0; padding: 0 1.15em 0 0;
+}
+.cook-ing-prep {
+  display: flex; gap: 10px; padding: 3px 0 3px var(--size-4-3, 12px);
+  color: var(--text-muted); font-size: 0.88em;
+}
+.cook-ing-prep-name { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.cook-ing-prep-qty { flex: none; font-variant-numeric: tabular-nums; }
 
 /* Cookware */
 .cook-cookware { margin-top: var(--size-4-6, 24px); }
@@ -410,6 +432,7 @@
 
 /* Inline components */
 .cook-ig-hl { color: var(--color-green, var(--text-accent)); font-weight: 600; }
+.cook-ig-prep { font-weight: 400; }
 .cook-cw-hl { color: var(--color-orange, var(--text-accent)); font-weight: 600; }
 .cook-amt { color: var(--text-muted); }
 .cook-timer-btn {
@@ -548,6 +571,7 @@
     align-items: center; justify-content: center;
     width: 48px; min-height: 48px; margin-block: -7px;
   }
+  .cook-ing-details > summary { min-height: 48px; }
   .cook-step-toggle {
     min-width: 48px; min-height: 48px; margin: -10px 0 -10px -10px;
   }
@@ -631,6 +655,7 @@
 
 .cook-stepper-btn:focus-visible,
 .cook-ing-checkbox:focus-visible,
+.cook-ing-details > summary:focus-visible,
 .cook-step-toggle:focus-visible,
 .cook-timer-btn:focus-visible,
 .cook-timer-reset-btn:focus-visible,

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -301,7 +301,8 @@ describe('RecipePreview', () => {
         const view = render(RecipePreview, { model: renderModel });
 
         expect(view.container.querySelector('.cook-ing-details')).toBeNull();
-        expect(view.container.querySelector('.cook-ing-single-prep')?.textContent).toContain('juice 1');
+        expect(view.container.querySelector('.cook-ing-single-prep')?.textContent.trim()).toBe('— juice');
+        expect(view.container.querySelector('.cook-ing-qty')?.textContent).toBe('1');
         expect(view.container.querySelector('.cook-step-text')?.textContent).toContain('lemon, juice');
         expect(view.container.querySelector('.cook-step-text')?.textContent).not.toContain('(1)');
     });

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -116,6 +116,43 @@ function recipe(): CooklangRecipe {
     } as unknown as CooklangRecipe;
 }
 
+function preparationRecipe(notes: Array<string | null> = ['juice', 'zest']): CooklangRecipe {
+    const ingredients = notes.map((note, index) => ({
+        name: 'lemon',
+        note,
+        reference: null,
+        quantity: {
+            value: { type: 'number', value: { type: 'regular', value: index === 0 ? 1 : 0.5 } },
+            unit: null,
+            display: index === 0 ? '1' : '0.5',
+        },
+    }));
+    return {
+        ...recipe(),
+        ingredients,
+        cookware: [],
+        timers: [],
+        inlineQuantities: [],
+        sections: [{
+            name: null,
+            content: [{
+                type: 'step',
+                value: {
+                    number: 1,
+                    items: [
+                        { type: 'text', value: 'Use ' },
+                        ...ingredients.flatMap((_, index) => [
+                            ...(index > 0 ? [{ type: 'text', value: ' and ' }] : []),
+                            { type: 'ingredient', index },
+                        ]),
+                        { type: 'text', value: '.' },
+                    ],
+                },
+            }],
+        }],
+    } as unknown as CooklangRecipe;
+}
+
 function model(overrides: Partial<RecipeRenderModel> = {}): RecipeRenderModel {
     const callbacks = {
         onScaleChange: vi.fn(),
@@ -230,6 +267,43 @@ describe('RecipePreview', () => {
         expect(screen.queryByRole('heading', { name: 'Cookware' })).toBeNull();
         expect(screen.queryByRole('heading', { name: 'Timers' })).toBeNull();
         expect(screen.queryByRole('button', { name: 'More servings' })).toBeNull();
+    });
+
+    it('expands multiple preparations without toggling the ingredient checkbox', async () => {
+        const renderModel = model({ recipe: preparationRecipe() });
+        const view = render(RecipePreview, { model: renderModel });
+
+        const details = view.container.querySelector<HTMLDetailsElement>('.cook-ing-details');
+        const summary = details?.querySelector<HTMLElement>('summary');
+        expect(details?.open).toBe(false);
+        expect(Array.from(details?.querySelectorAll('.cook-ing-prep') ?? [], item => item.textContent)).toEqual([
+            'juice 1',
+            'zest 0.5',
+        ]);
+
+        await fireEvent.click(summary!);
+        expect(details?.open).toBe(true);
+        expect(renderModel.callbacks.onIngredientToggle).not.toHaveBeenCalled();
+
+        await fireEvent.click(summary!.querySelector('.cook-ing-name')!);
+        expect(details?.open).toBe(false);
+        expect(renderModel.callbacks.onIngredientToggle).not.toHaveBeenCalled();
+
+        await fireEvent.click(screen.getByRole('checkbox', { name: 'Check lemon' }));
+        expect(renderModel.callbacks.onIngredientToggle).toHaveBeenCalledWith('lemon');
+    });
+
+    it('shows one preparation inline and keeps it in the method when quantities are hidden', () => {
+        const renderModel = model({
+            recipe: preparationRecipe(['juice']),
+            settings: { ...settings(), showQuantitiesInline: false },
+        });
+        const view = render(RecipePreview, { model: renderModel });
+
+        expect(view.container.querySelector('.cook-ing-details')).toBeNull();
+        expect(view.container.querySelector('.cook-ing-single-prep')?.textContent).toContain('juice 1');
+        expect(view.container.querySelector('.cook-step-text')?.textContent).toContain('lemon, juice');
+        expect(view.container.querySelector('.cook-step-text')?.textContent).not.toContain('(1)');
     });
 
 });

--- a/src/ui/components/IngredientList.svelte
+++ b/src/ui/components/IngredientList.svelte
@@ -71,9 +71,7 @@
                                         {/if}
                                         {#if singlePreparation}
                                             <span class="cook-ing-single-prep">
-                                                — {singlePreparation.name}{#if singlePreparation.displayQty}
-                                                    {' '}<span class="cook-ing-prep-qty">{singlePreparation.displayQty}</span>
-                                                {/if}
+                                                — {singlePreparation.name}
                                             </span>
                                         {/if}
                                     </span>

--- a/src/ui/components/IngredientList.svelte
+++ b/src/ui/components/IngredientList.svelte
@@ -18,6 +18,7 @@
                 {#each group.rows as row, rowIndex}
                     {@const inputId = `${model.instanceId}-ingredient-${groupIndex}-${rowIndex}`}
                     {@const checked = model.state.checkedIngredients.has(row.name)}
+                    {@const singlePreparation = row.preparations.length === 1 ? row.preparations[0] : null}
                     <li class:done={checked} class="cook-ing">
                         {#if model.interactive}
                             <label class="cook-ing-checkbox-hit">
@@ -33,18 +34,55 @@
                         {:else}
                             <span class="cook-ing-checkbox" aria-hidden="true"></span>
                         {/if}
-                        <span class="cook-ing-name">
-                            {#if row.reference}
-                                <ReferenceLink {model} reference={row.reference} />
-                            {:else if model.interactive}
-                                <label for={inputId}>{row.name}</label>
+                        <div class="cook-ing-content">
+                            {#if row.preparations.length > 1}
+                                <details class="cook-ing-details">
+                                    <summary class="cook-ing-main">
+                                        <span class="cook-ing-name">
+                                            {#if row.reference}
+                                                <ReferenceLink {model} reference={row.reference} />
+                                            {:else}
+                                                {row.name}
+                                            {/if}
+                                        </span>
+                                        {#if row.displayQty}
+                                            <span class="cook-ing-qty">{row.displayQty}</span>
+                                        {/if}
+                                        <span class="cook-ing-disclosure-icon" aria-hidden="true"></span>
+                                    </summary>
+                                    <ul class="cook-ing-prep-list">
+                                        {#each row.preparations as preparation}
+                                            <li class="cook-ing-prep">
+                                                <span class="cook-ing-prep-name">{preparation.name}</span>
+                                                {#if preparation.displayQty}
+                                                    <span class="cook-ing-prep-qty">{preparation.displayQty}</span>
+                                                {/if}
+                                            </li>
+                                        {/each}
+                                    </ul>
+                                </details>
                             {:else}
-                                {row.name}
+                                <div class="cook-ing-main">
+                                    <span class="cook-ing-name">
+                                        {#if row.reference}
+                                            <ReferenceLink {model} reference={row.reference} />
+                                        {:else}
+                                            {row.name}
+                                        {/if}
+                                        {#if singlePreparation}
+                                            <span class="cook-ing-single-prep">
+                                                — {singlePreparation.name}{#if singlePreparation.displayQty}
+                                                    {' '}<span class="cook-ing-prep-qty">{singlePreparation.displayQty}</span>
+                                                {/if}
+                                            </span>
+                                        {/if}
+                                    </span>
+                                    {#if row.displayQty}
+                                        <span class="cook-ing-qty">{row.displayQty}</span>
+                                    {/if}
+                                </div>
                             {/if}
-                        </span>
-                        {#if row.displayQty}
-                            <span class="cook-ing-qty">{row.displayQty}</span>
-                        {/if}
+                        </div>
                     </li>
                 {/each}
             </ul>

--- a/src/ui/components/StepPart.svelte
+++ b/src/ui/components/StepPart.svelte
@@ -40,8 +40,7 @@
             />
         {:else}
             {ingredient_display_name(part.ingredient)}
-        {/if}
-        {#if model.settings.showQuantitiesInline && part.ingredient.quantity}
+        {/if}{#if part.ingredient.note?.trim()}<span class="cook-ig-prep">, {part.ingredient.note.trim()}</span>{/if}{#if model.settings.showQuantitiesInline && part.ingredient.quantity}
             {' '}<span class="cook-amt">({quantity_display(part.ingredient.quantity)})</span>
         {/if}
     </span>

--- a/src/utils/ingredientAggregator.test.ts
+++ b/src/utils/ingredientAggregator.test.ts
@@ -88,15 +88,53 @@ describe('aggregateIngredients', () => {
     it('null displayQty when no amounts', () => {
         const rows = aggregateIngredients([ing({ name: 'salt' })]);
         expect(rows[0].displayQty).toBeNull();
+        expect(rows[0].preparations).toEqual([]);
     });
 
-    it('carries the first reference and note found', () => {
+    it('carries the first reference and preparation found', () => {
         const ref = { name: 'Beans', components: ['.', 'Components'] };
         const rows = aggregateIngredients([
             ing({ name: 'Beans', quantityValue: 2, unit: 'servings', reference: ref, note: 'warm' }),
         ]);
         expect(rows[0].reference).toEqual(ref);
-        expect(rows[0].note).toBe('warm');
+        expect(rows[0].preparations).toEqual([{ name: 'warm', displayQty: '2 servings' }]);
         expect(rows[0].displayQty).toBe('2 servings');
+    });
+
+    it('keeps preparation quantities separate and in first-seen order', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'lemon', quantityValue: 1, note: 'juice' }),
+            ing({ name: 'lemon', quantityValue: 0.5, note: 'zest' }),
+        ]);
+
+        expect(rows[0].displayQty).toBe('1.5');
+        expect(rows[0].preparations).toEqual([
+            { name: 'juice', displayQty: '1' },
+            { name: 'zest', displayQty: '0.5' },
+        ]);
+    });
+
+    it('combines repeated preparations with the normal quantity rules', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'onion', quantityValue: 150, unit: 'g', note: 'diced' }),
+            ing({ name: 'onion', quantityValue: 1.35, unit: 'kg', note: 'diced' }),
+            ing({ name: 'onion', quantityValue: 1, unit: 'tbsp', note: 'fried' }),
+        ]);
+
+        expect(rows[0].preparations).toEqual([
+            { name: 'diced', displayQty: '1.5 kg' },
+            { name: 'fried', displayQty: '1 tbsp' },
+        ]);
+    });
+
+    it('omits unprepared and empty-note occurrences from the breakdown', () => {
+        const rows = aggregateIngredients([
+            ing({ name: 'lemon', quantityValue: 1 }),
+            ing({ name: 'lemon', quantityValue: 0.5, note: 'juice' }),
+            ing({ name: 'lemon', quantityValue: 0.25, note: '   ' }),
+        ]);
+
+        expect(rows[0].displayQty).toBe('1.75');
+        expect(rows[0].preparations).toEqual([{ name: 'juice', displayQty: '0.5' }]);
     });
 });

--- a/src/utils/ingredientAggregator.ts
+++ b/src/utils/ingredientAggregator.ts
@@ -42,8 +42,14 @@ export interface IngredientRow {
     name: string;
     /** Combined quantity text, or null when there's no amount. */
     displayQty: string | null;
-    note: string | null;
+    /** Preparation-specific quantities, in first-seen order. */
+    preparations: IngredientPreparationRow[];
     reference: RecipeRefTarget | null;
+}
+
+export interface IngredientPreparationRow {
+    name: string;
+    displayQty: string | null;
 }
 
 /** Round to 2 decimals and drop trailing zeros: 5.6667 -> "5.67", 16.5 -> "16.5". */
@@ -58,6 +64,11 @@ unitMath.createUnit('tsp', '1 teaspoon');
 type QuantityBucket =
     | { type: 'unit'; total: Unit }
     | { type: 'raw'; key: string; sum: number; unitDisplay: string };
+
+interface QuantityAccumulator {
+    quantities: QuantityBucket[];
+    textParts: string[];
+}
 
 const MATHJS_UNIT_ALIASES: Record<string, string> = {
     'fl oz': 'floz',
@@ -79,13 +90,58 @@ function parsedUnit(value: number, unit: string | null): Unit | null {
     }
 }
 
+function addQuantity(accumulator: QuantityAccumulator, item: AggInput): void {
+    if (item.quantityValue !== null) {
+        const quantity = parsedUnit(item.quantityValue, item.unit);
+        if (quantity) {
+            const bucket = accumulator.quantities.find(
+                (candidate): candidate is Extract<QuantityBucket, { type: 'unit' }> =>
+                    candidate.type === 'unit' && candidate.total.equalBase(quantity),
+            );
+            if (bucket) {
+                bucket.total = unitMath.add(bucket.total, quantity) as Unit;
+            } else {
+                accumulator.quantities.push({ type: 'unit', total: quantity });
+            }
+        } else {
+            const key = normalizeUnit(item.unit);
+            const bucket = accumulator.quantities.find(
+                (candidate): candidate is Extract<QuantityBucket, { type: 'raw' }> =>
+                    candidate.type === 'raw' && candidate.key === key,
+            );
+            if (bucket) {
+                bucket.sum += item.quantityValue;
+            } else {
+                accumulator.quantities.push({
+                    type: 'raw',
+                    key,
+                    sum: item.quantityValue,
+                    unitDisplay: item.unit ?? '',
+                });
+            }
+        }
+    } else if (item.quantityText) {
+        accumulator.textParts.push(item.quantityText);
+    }
+}
+
+function displayQuantity(accumulator: QuantityAccumulator): string | null {
+    const parts = accumulator.quantities.map(bucket => bucket.type === 'unit'
+        ? bucket.total.toBest().format({ precision: 3 })
+        : bucket.unitDisplay
+            ? `${formatQuantity(bucket.sum)} ${bucket.unitDisplay}`
+            : formatQuantity(bucket.sum));
+    parts.push(...accumulator.textParts);
+    return parts.length ? parts.join(' + ') : null;
+}
+
 export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
     const order: string[] = [];
     const groups = new Map<string, {
         name: string;
-        quantities: QuantityBucket[];
-        textParts: string[];
-        note: string | null;
+        total: QuantityAccumulator;
+        preparationOrder: string[];
+        preparations: Map<string, QuantityAccumulator>;
         reference: RecipeRefTarget | null;
     }>();
 
@@ -94,64 +150,40 @@ export function aggregateIngredients(items: AggInput[]): IngredientRow[] {
         if (!group) {
             group = {
                 name: item.name,
-                quantities: [],
-                textParts: [],
-                note: null,
+                total: { quantities: [], textParts: [] },
+                preparationOrder: [],
+                preparations: new Map(),
                 reference: null,
             };
             groups.set(item.name, group);
             order.push(item.name);
         }
 
-        if (item.quantityValue !== null) {
-            const quantity = parsedUnit(item.quantityValue, item.unit);
-            if (quantity) {
-                const bucket = group.quantities.find(
-                    (candidate): candidate is Extract<QuantityBucket, { type: 'unit' }> =>
-                        candidate.type === 'unit' && candidate.total.equalBase(quantity),
-                );
-                if (bucket) {
-                    bucket.total = unitMath.add(bucket.total, quantity) as Unit;
-                } else {
-                    group.quantities.push({ type: 'unit', total: quantity });
-                }
-            } else {
-                const key = normalizeUnit(item.unit);
-                const bucket = group.quantities.find(
-                    (candidate): candidate is Extract<QuantityBucket, { type: 'raw' }> =>
-                        candidate.type === 'raw' && candidate.key === key,
-                );
-                if (bucket) {
-                    bucket.sum += item.quantityValue;
-                } else {
-                    group.quantities.push({
-                        type: 'raw',
-                        key,
-                        sum: item.quantityValue,
-                        unitDisplay: item.unit ?? '',
-                    });
-                }
+        addQuantity(group.total, item);
+
+        const preparationName = item.note?.trim();
+        if (preparationName) {
+            let preparation = group.preparations.get(preparationName);
+            if (!preparation) {
+                preparation = { quantities: [], textParts: [] };
+                group.preparations.set(preparationName, preparation);
+                group.preparationOrder.push(preparationName);
             }
-        } else if (item.quantityText) {
-            group.textParts.push(item.quantityText);
+            addQuantity(preparation, item);
         }
 
-        if (group.note === null && item.note) group.note = item.note;
         if (group.reference === null && item.reference) group.reference = item.reference;
     }
 
     return order.map(name => {
         const group = groups.get(name)!;
-        const parts = group.quantities.map(bucket => bucket.type === 'unit'
-            ? bucket.total.toBest().format({ precision: 3 })
-            : bucket.unitDisplay
-                ? `${formatQuantity(bucket.sum)} ${bucket.unitDisplay}`
-                : formatQuantity(bucket.sum));
-        parts.push(...group.textParts);
         return {
             name: group.name,
-            displayQty: parts.length ? parts.join(' + ') : null,
-            note: group.note,
+            displayQty: displayQuantity(group.total),
+            preparations: group.preparationOrder.map(preparationName => ({
+                name: preparationName,
+                displayQty: displayQuantity(group.preparations.get(preparationName)!),
+            })),
             reference: group.reference,
         };
     });


### PR DESCRIPTION
## Summary

- show Cooklang shorthand preparations inline in method steps
- keep one aggregated ingredient row while exposing preparation-specific quantities
- render a single preparation inline and multiple preparations in a collapsed disclosure
- restrict checklist toggling to the checkbox and keep it aligned with the parent row

Closes #136.

## Testing

- `npm run typecheck`
- `npm test` (109 tests)
- `npm run build`