### PR TITLE
feat: improve recipe previews and reference scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ A plugin for [Obsidian](https://obsidian.md) adding support for [Cooklang](https
 Opening a `.cook` file and toggling Preview shows a single rich recipe page:
 
 - **Hero** with the recipe title, description, **title image** (a sibling file named like
-  the recipe, e.g. `Curry.jpg`), and meta pills for total time, servings, difficulty,
-  source and tags.
+  the recipe, e.g. `Curry.jpg`, or the first URL in `image`/`images` metadata), and meta
+  pills for total time, servings, difficulty, source and tags. Metadata image URLs are
+  loaded from their remote hosts when the preview is open and images are enabled.
 - **Servings scaler** — a `− N servings +` control in the sticky bar that rescales every
   ingredient quantity (and inline quantities in the steps) in real time.
 - **Two-column layout** on wide panes: a sticky ingredient checklist beside the steps; it
@@ -26,7 +27,7 @@ Opening a `.cook` file and toggling Preview shows a single rich recipe page:
 - **Cooklang sections** (`= Section =`) group both the ingredients and the steps, and
   `> notes` render as callouts.
 - **Per-step images** following the [Cooklang convention](https://cooklang.org/docs/spec/#adding-pictures)
-  (`Recipe.0.jpg` for the first step, `Recipe.1.jpg` for the second, …).
+  (`Recipe.1.jpg` for the first step, `Recipe.2.jpg` for the second, …).
 - **Step tracking** — tap a step to mark it current and dim completed steps.
 
 Each of these can be toggled in the plugin settings (Servings scaler, Two-column layout,
@@ -35,10 +36,13 @@ Step tracking), falling back to a simple stacked list.
 ## Recipe references
 
 Reference another recipe with Cooklang ingredient syntax, for example
-`@./Components/Beans`. References resolve relative to the recipe containing
-them. The plugin opens a matching `.cook` file first, following the Cooklang
-convention. If no `.cook` file exists, it falls back to a same-path Markdown
-file only when its frontmatter contains the Boolean flag:
+`@./Components/Beans`. References resolve relative to the root of the vault,
+which acts as the Cooklang recipes root. The plugin opens a matching `.cook`
+file first, following the Cooklang convention. A quantity such as `{2}` opens
+the target at twice its base scale, `{4%servings}` targets four servings, and a
+quantity matching the target's `yield` unit scales to that yield. If no `.cook`
+file exists, the plugin falls back to a same-path Markdown file only when its
+frontmatter contains the Boolean flag:
 
 ```yaml
 ---

--- a/src/cookView.ts
+++ b/src/cookView.ts
@@ -8,7 +8,13 @@ import {defaultKeymap} from "@codemirror/commands"
 import {cooklang, cooklangHighlighter} from './mode/cook/cook'
 import { parserService } from './services/ParserService';
 import { TimerService } from './services/TimerService';
-import { parseServingsValue, computeScale, deriveServingsState } from './utils/scaling';
+import {
+    parseServingsValue,
+    computeScale,
+    computeReferenceScale,
+    deriveServingsState,
+    type RecipeReferenceScaleRequest,
+} from './utils/scaling';
 import alarmMp3 from './alarm.mp3';
 import timerMp3 from './timer.mp3';
 import { flushSync, mount, unmount } from 'svelte';
@@ -43,6 +49,7 @@ export class CookView extends TextFileView {
     checkedIngredients: Set<string> = new Set();
     scale: number = 1;
     currentStep: number = -1;
+    private pendingReferenceScale: RecipeReferenceScaleRequest | null = null;
 
     constructor(leaf: WorkspaceLeaf, settings: CooklangSettings) {
         super(leaf);
@@ -334,6 +341,9 @@ export class CookView extends TextFileView {
 
     // Override to restore the mode from view state
     async setState(state: any, result: ViewStateResult) {
+        this.pendingReferenceScale = isReferenceScaleRequest(state.referenceScale)
+            ? state.referenceScale
+            : null;
         await super.setState(state, result);
         if (typeof state.scale === 'number' && state.scale > 0) this.scale = state.scale;
         if (typeof state.currentStep === 'number') this.currentStep = state.currentStep;
@@ -363,7 +373,7 @@ export class CookView extends TextFileView {
         if (!parserService.isReady()) return;
 
         // Re-parse at the current scale so quantities (list + inline) rescale.
-        const [rawRecipe] = parserService.parse(this.data, this.scale);
+        let [rawRecipe] = parserService.parse(this.data, this.scale);
         this.rawRecipe = rawRecipe;
 
         // The parser scales (and rounds) the `servings` metadata, so the servings
@@ -371,6 +381,16 @@ export class CookView extends TextFileView {
         // a scale-1 parse to compute scale targets and the displayed count
         // correctly (see issue #83).
         const [baseRecipe] = parserService.parse(this.data);
+        if (this.pendingReferenceScale) {
+            this.scale = computeReferenceScale(
+                this.pendingReferenceScale,
+                baseRecipe.servings,
+                baseRecipe.rawMetadata.get('yield'),
+            );
+            this.pendingReferenceScale = null;
+            [rawRecipe] = parserService.parse(this.data, this.scale);
+            this.rawRecipe = rawRecipe;
+        }
         const { baseServings, displayServings } = deriveServingsState(
             parseServingsValue(baseRecipe.servings),
             this.scale,
@@ -419,4 +439,11 @@ export class CookView extends TextFileView {
         if (lineWrapChanged) this.reinitializeEditor();
         if (this.currentView === 'preview') this.renderPreview();
     }
+}
+
+function isReferenceScaleRequest(value: unknown): value is RecipeReferenceScaleRequest {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<RecipeReferenceScaleRequest>;
+    return typeof candidate.quantity === 'number'
+        && (typeof candidate.unit === 'string' || candidate.unit === null);
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -418,7 +418,7 @@
   -webkit-appearance: none; appearance: none; background: transparent; cursor: pointer; font: inherit;
 }
 .cook-step-bodywrap { flex: 1; min-width: 0; }
-.cook-step-text { line-height: 1.6; }
+.cook-step-text { line-height: 1.6; white-space: pre-line; }
 .cook-ingredients,
 .cook-steps { scroll-margin-top: 64px; }
 .cook-step-image { margin: var(--size-4-2, 8px) 0 0; }

--- a/src/ui/ObsidianRecipeHost.ts
+++ b/src/ui/ObsidianRecipeHost.ts
@@ -17,10 +17,8 @@ export class ObsidianRecipeHost implements RecipeHostAdapter {
         sourceFile: TFile | null,
         ref: RecipeRefTarget,
     ): ResolvedRecipeReference | null {
-        const folder = sourceFile?.parent?.path ?? '';
-        const normalizedFolder = folder === '/' ? '' : folder;
         const [cookPath, markdownPath] = resolveReferenceCandidatePaths(
-            normalizedFolder,
+            '',
             ref.components ?? [],
             ref.name,
         );
@@ -37,11 +35,22 @@ export class ObsidianRecipeHost implements RecipeHostAdapter {
             ? {
                 targetPath: target.path,
                 sourcePath: sourceFile?.path ?? '',
+                scaleRequest: ref.quantity !== null && ref.quantity > 0
+                    ? { quantity: ref.quantity, unit: ref.unit }
+                    : null,
             }
             : null;
     }
 
     openReference(reference: ResolvedRecipeReference): void {
-        this.app.workspace.openLinkText(reference.targetPath, reference.sourcePath, false);
+        const leaf = this.app.workspace.getLeaf(false);
+        void leaf.setViewState({
+            type: 'cook',
+            state: {
+                file: reference.targetPath,
+                mode: 'preview',
+                referenceScale: reference.scaleRequest,
+            },
+        });
     }
 }

--- a/src/ui/RecipePreview.svelte
+++ b/src/ui/RecipePreview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { findRecipeImages } from '../utils/imageHelpers';
+    import { getRecipeImageUrls } from '../utils/recipeImages';
     import CookwareList from './components/CookwareList.svelte';
     import Hero from './components/Hero.svelte';
     import IngredientList from './components/IngredientList.svelte';
@@ -11,9 +12,10 @@
 
     let { model }: { model: RecipeRenderModel } = $props();
     let images = $derived(findRecipeImages(model.file));
+    let mainImage = $derived(images.mainImage ?? getRecipeImageUrls(model.recipe.images)[0] ?? null);
 </script>
 
-<Hero {model} mainImage={images.mainImage} />
+<Hero {model} {mainImage} />
 <ScalerBar {model} />
 
 <div class:cook-cols-stacked={!model.settings.twoColumnLayout} class="cook-cols">

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -269,6 +269,15 @@ describe('RecipePreview', () => {
         expect(screen.queryByRole('button', { name: 'More servings' })).toBeNull();
     });
 
+    it('renders the heading for a single explicitly named section', () => {
+        const namedSectionRecipe = recipe();
+        namedSectionRecipe.sections[0].name = 'Sauce';
+
+        render(RecipePreview, { model: model({ recipe: namedSectionRecipe }) });
+
+        expect(screen.getByRole('heading', { name: 'Sauce', level: 3 })).toBeTruthy();
+    });
+
     it('expands multiple preparations without toggling the ingredient checkbox', async () => {
         const renderModel = model({ recipe: preparationRecipe() });
         const view = render(RecipePreview, { model: renderModel });

--- a/src/ui/RecipePreview.test.ts
+++ b/src/ui/RecipePreview.test.ts
@@ -269,6 +269,51 @@ describe('RecipePreview', () => {
         expect(screen.queryByRole('button', { name: 'More servings' })).toBeNull();
     });
 
+    it('uses the first parsed image URL when no sibling title image exists', () => {
+        const recipeWithImages = recipe();
+        recipeWithImages.images = [
+            'https://example.com/curry.jpg',
+            'https://example.com/curry-alt.jpg',
+        ];
+
+        render(RecipePreview, { model: model({ recipe: recipeWithImages }) });
+
+        expect(screen.getByRole('img', { name: 'Weeknight curry recipe' }).getAttribute('src'))
+            .toBe('https://example.com/curry.jpg');
+        expect(screen.queryByText('https://example.com/curry.jpg')).toBeNull();
+    });
+
+    it('does not render parsed image metadata when images are disabled', () => {
+        const recipeWithImage = recipe();
+        recipeWithImage.images = 'https://example.com/curry.jpg';
+
+        render(RecipePreview, {
+            model: model({
+                recipe: recipeWithImage,
+                settings: { ...settings(), showImages: false },
+            }),
+        });
+
+        expect(screen.queryByRole('img', { name: 'Weeknight curry recipe' })).toBeNull();
+    });
+
+    it('only makes HTTP(S) metadata values actionable', () => {
+        const recipeWithLinks = recipe();
+        recipeWithLinks.source = { name: 'Unsafe source', url: 'javascript:alert(1)' };
+        recipeWithLinks.rawMetadata = new Map([
+            ['title', 'Weeknight curry'],
+            ['website', 'https://example.com/recipe'],
+            ['script', 'javascript:alert(2)'],
+        ]);
+
+        render(RecipePreview, { model: model({ recipe: recipeWithLinks }) });
+
+        expect(screen.getByText('Unsafe source').closest('a')).toBeNull();
+        expect(screen.getByText('https://example.com/recipe').closest('a')?.getAttribute('href'))
+            .toBe('https://example.com/recipe');
+        expect(screen.getByText('javascript:alert(2)').closest('a')).toBeNull();
+    });
+
     it('renders the heading for a single explicitly named section', () => {
         const namedSectionRecipe = recipe();
         namedSectionRecipe.sections[0].name = 'Sauce';
@@ -323,6 +368,7 @@ describe('ReferenceLink', () => {
         const reference: ResolvedRecipeReference = {
             targetPath: 'Components/Sauce.cook',
             sourcePath: 'Dinner.cook',
+            scaleRequest: null,
         };
         const renderModel = model({
             host: {
@@ -333,7 +379,7 @@ describe('ReferenceLink', () => {
         });
         render(ReferenceLink, {
             model: renderModel,
-            reference: { name: 'Sauce', components: ['Components'] },
+            reference: { name: 'Sauce', components: ['Components'], quantity: null, unit: null },
         });
 
         await fireEvent.click(screen.getByRole('link', { name: 'Sauce' }));

--- a/src/ui/components/Hero.svelte
+++ b/src/ui/components/Hero.svelte
@@ -3,10 +3,13 @@
     import { buildMetaPills } from '../../utils/heroModel';
     import type { RecipeRenderModel } from '../types';
 
-    let { model, mainImage }: { model: RecipeRenderModel; mainImage: TFile | null } = $props();
+    let { model, mainImage }: { model: RecipeRenderModel; mainImage: TFile | string | null } = $props();
     let title = $derived(model.recipe.title?.trim() || model.file?.basename || 'Recipe');
     let description = $derived(model.recipe.description?.trim());
     let pills = $derived(buildMetaPills(model.recipe, model.state.displayServings));
+    let mainImageUrl = $derived(
+        typeof mainImage === 'string' ? mainImage : mainImage ? model.host.getResourcePath(mainImage) : null
+    );
 </script>
 
 <header class="cook-hero">
@@ -39,9 +42,9 @@
         {/if}
     </div>
 
-    {#if model.settings.showImages && mainImage}
+    {#if model.settings.showImages && mainImageUrl}
         <figure class="cook-hero-image">
-            <img src={model.host.getResourcePath(mainImage)} alt={`${title} recipe`} />
+            <img src={mainImageUrl} alt={`${title} recipe`} />
         </figure>
     {/if}
 </header>

--- a/src/ui/components/Metadata.svelte
+++ b/src/ui/components/Metadata.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { getAdditionalMetadata } from '../../utils/metadataEntries';
-    import { isValidUrl } from '../../utils/urlValidators';
+    import { getSafeExternalUrl } from '../../utils/urlValidators';
     import type { RecipeRenderModel } from '../types';
 
     let { model }: { model: RecipeRenderModel } = $props();
@@ -12,10 +12,11 @@
         <summary class="cook-more-summary">{model.settings.metadataLabel || 'More details'}</summary>
         <ul class="cook-more-list">
             {#each entries as entry}
+                {@const url = getSafeExternalUrl(entry.value)}
                 <li>
                     <span class="cook-more-key">{entry.key}</span>
-                    {#if isValidUrl(entry.value)}
-                        <a href={entry.value} target="_blank" rel="noopener noreferrer">{entry.value}</a>
+                    {#if url}
+                        <a href={url} target="_blank" rel="noopener noreferrer">{entry.value}</a>
                     {:else}
                         {entry.value}
                     {/if}

--- a/src/ui/components/MethodSteps.svelte
+++ b/src/ui/components/MethodSteps.svelte
@@ -42,7 +42,7 @@
 <section class="cook-steps" id="cook-steps">
     <h2 class="cook-section-title">{model.settings.methodLabel || 'Method'}</h2>
     {#each sections as section}
-        {#if section.name && sections.length > 1}
+        {#if section.name}
             <h3 class="cook-section-band">{section.name}</h3>
         {/if}
         {#each section.entries as entry}

--- a/src/ui/components/StepPart.svelte
+++ b/src/ui/components/StepPart.svelte
@@ -5,6 +5,7 @@
         quantity_display,
     } from '../../recipeHelpers';
     import { formatTimerDuration, timerDurationFromQuantity } from '../../utils/timeFormatters';
+    import { numericFromQuantity } from '../../utils/quantityValue';
     import type { StepPart } from '../../utils/sectionHelpers';
     import type { RecipeRenderModel } from '../types';
     import ReferenceLink from './ReferenceLink.svelte';
@@ -36,6 +37,10 @@
                 reference={{
                     name: part.ingredient.reference.name,
                     components: part.ingredient.reference.components ?? [],
+                    quantity: part.ingredient.quantity
+                        ? numericFromQuantity(part.ingredient.quantity)
+                        : null,
+                    unit: part.ingredient.quantity?.unit ?? null,
                 }}
             />
         {:else}

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -4,6 +4,7 @@ import type { Readable } from 'svelte/store';
 import type { CooklangSettings } from '../settings';
 import type { RecipeRefTarget } from '../utils/ingredientAggregator';
 import type { TimerSnapshot } from '../services/TimerService';
+import type { RecipeReferenceScaleRequest } from '../utils/scaling';
 
 export type CookViewMode = 'source' | 'preview';
 
@@ -24,6 +25,7 @@ export interface PreviewCallbacks {
 export interface ResolvedRecipeReference {
     targetPath: string;
     sourcePath: string;
+    scaleRequest: RecipeReferenceScaleRequest | null;
 }
 
 export interface RecipeHostAdapter {

--- a/src/utils/heroModel.test.ts
+++ b/src/utils/heroModel.test.ts
@@ -48,6 +48,26 @@ describe('buildMetaPills', () => {
         expect(pill!.url).toBe('https://jane.example');
     });
 
+    it('keeps unsafe author and source URLs visible as text but not as links', () => {
+        const recipe = {
+            author: { name: 'Jane Cook', url: 'javascript:alert(1)' },
+            source: { name: null, url: 'data:text/html,dinner' },
+            tags: new Set(),
+        } as any;
+        const pills = buildMetaPills(recipe, null);
+
+        expect(pills.find(p => p.kind === 'author')).toEqual({
+            kind: 'author',
+            icon: '✍',
+            text: 'Jane Cook',
+        });
+        expect(pills.find(p => p.kind === 'source')).toEqual({
+            kind: 'source',
+            icon: '↗',
+            text: 'data:text/html,dinner',
+        });
+    });
+
     it('emits no pills when nothing is present', () => {
         const recipe = { tags: new Set() } as any;
         expect(buildMetaPills(recipe, null)).toEqual([]);

--- a/src/utils/heroModel.ts
+++ b/src/utils/heroModel.ts
@@ -2,6 +2,7 @@
  * Pure model for hero meta pills, derived from the typed recipe fields.
  */
 import type { CooklangRecipe } from '@cooklang/cooklang';
+import { getSafeExternalUrl } from './urlValidators';
 
 // `@cooklang/cooklang` does not re-export its `RecipeTime` type, so mirror it
 // locally (minutes as a number, or a prep/cook breakdown).
@@ -85,14 +86,16 @@ export function buildMetaPills(
     if (recipe.author) {
         const text = recipe.author.name ?? recipe.author.url ?? null;
         if (text) {
-            pills.push({ kind: 'author', icon: '✍', text, url: recipe.author.url });
+            const url = getSafeExternalUrl(recipe.author.url);
+            pills.push({ kind: 'author', icon: '✍', text, ...(url ? { url } : {}) });
         }
     }
 
     if (recipe.source) {
         const text = recipe.source.name ?? recipe.source.url ?? null;
         if (text) {
-            pills.push({ kind: 'source', icon: '↗', text, url: recipe.source.url });
+            const url = getSafeExternalUrl(recipe.source.url);
+            pills.push({ kind: 'source', icon: '↗', text, ...(url ? { url } : {}) });
         }
     }
 

--- a/src/utils/ingredientAggregator.test.ts
+++ b/src/utils/ingredientAggregator.test.ts
@@ -92,7 +92,12 @@ describe('aggregateIngredients', () => {
     });
 
     it('carries the first reference and preparation found', () => {
-        const ref = { name: 'Beans', components: ['.', 'Components'] };
+        const ref = {
+            name: 'Beans',
+            components: ['.', 'Components'],
+            quantity: 2,
+            unit: 'servings',
+        };
         const rows = aggregateIngredients([
             ing({ name: 'Beans', quantityValue: 2, unit: 'servings', reference: ref, note: 'warm' }),
         ]);

--- a/src/utils/ingredientAggregator.ts
+++ b/src/utils/ingredientAggregator.ts
@@ -23,6 +23,10 @@ export interface RecipeRefTarget {
     name: string;
     /** Path components from the reference, e.g. [".", "Components"]. */
     components: string[];
+    /** Numeric reference request (`{2}`, `{4%servings}`, `{150%ml}`). */
+    quantity: number | null;
+    /** Unit for servings/yield scaling; null means a direct multiplier. */
+    unit: string | null;
 }
 
 export interface AggInput {

--- a/src/utils/ingredientRows.ts
+++ b/src/utils/ingredientRows.ts
@@ -45,6 +45,8 @@ export function ingredientToAggInput(ingredient: Ingredient): AggInput {
             ? {
                 name: ingredient.reference.name,
                 components: ingredient.reference.components ?? [],
+                quantity: quantityValue,
+                unit,
             }
             : null,
     };

--- a/src/utils/metadataEntries.test.ts
+++ b/src/utils/metadataEntries.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { CooklangRecipe } from '@cooklang/cooklang';
+import { getAdditionalMetadata } from './metadataEntries';
+
+function recipe(
+    metadata: Array<[string, string]>,
+    fields: Partial<CooklangRecipe> = {},
+): CooklangRecipe {
+    return {
+        rawMetadata: new Map(metadata),
+        tags: new Set(),
+        ...fields,
+    } as unknown as CooklangRecipe;
+}
+
+describe('getAdditionalMetadata', () => {
+    it('omits canonical metadata that is represented elsewhere in the preview', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['title', 'Dinner'],
+            ['description', 'Fast.'],
+            ['servings', '4'],
+            ['time', '45 min'],
+            ['tags', 'quick'],
+            ['source', 'https://example.com'],
+            ['author', 'Jane'],
+            ['difficulty', 'easy'],
+            ['course', 'dinner'],
+            ['cuisine', 'Thai'],
+            ['diet', 'vegan'],
+            ['image', 'https://example.com/dinner.jpg'],
+            ['oven', '220 C'],
+        ], {
+            title: 'Dinner',
+            description: 'Fast.',
+            servings: 4,
+            time: 45,
+            tags: new Set(['quick']),
+            source: { name: undefined, url: 'https://example.com' },
+            author: { name: 'Jane', url: undefined },
+            difficulty: 'easy',
+            course: 'dinner',
+            cuisine: 'Thai',
+            diet: 'vegan',
+            images: 'https://example.com/dinner.jpg',
+        }));
+
+        expect(result).toEqual([{ key: 'oven', value: '220 C' }]);
+    });
+
+    it('preserves unsupported aliases even when a related canonical field exists', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['servings', '4'],
+            ['serves', '6'],
+            ['yield', '2 loaves'],
+            ['tags', 'quick'],
+            ['tag', 'weeknight'],
+            ['image', 'https://example.com/main.jpg'],
+            ['images', 'https://example.com/other.jpg'],
+            ['picture', 'https://example.com/picture.jpg'],
+            ['pictures', 'https://example.com/pictures.jpg'],
+            ['prep_time', '10 min'],
+            ['cook_time', '20 min'],
+        ], {
+            servings: 4,
+            tags: new Set(['quick']),
+            images: 'https://example.com/main.jpg',
+        }));
+
+        expect(result).toEqual([
+            { key: 'serves', value: '6' },
+            { key: 'yield', value: '2 loaves' },
+            { key: 'tag', value: 'weeknight' },
+            { key: 'images', value: 'https://example.com/other.jpg' },
+            { key: 'picture', value: 'https://example.com/picture.jpg' },
+            { key: 'pictures', value: 'https://example.com/pictures.jpg' },
+            { key: 'prep_time', value: '10 min' },
+            { key: 'cook_time', value: '20 min' },
+        ]);
+    });
+
+    it('preserves case variants because parser metadata keys are case-sensitive', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['title', 'Canonical title'],
+            ['Title', 'Unparsed title'],
+            ['TIME', '45 min'],
+            ['Image', 'https://example.com/dinner.jpg'],
+        ], {
+            title: 'Canonical title',
+        }));
+
+        expect(result).toEqual([
+            { key: 'Title', value: 'Unparsed title' },
+            { key: 'TIME', value: '45 min' },
+            { key: 'Image', value: 'https://example.com/dinner.jpg' },
+        ]);
+    });
+
+    it('preserves canonical keys when the parser did not produce renderable values', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['time', 'whenever'],
+            ['tags', ''],
+            ['image', 'javascript:alert(1)'],
+        ], {
+            time: undefined,
+            tags: new Set(),
+            images: 'javascript:alert(1)',
+        }));
+
+        expect(result).toEqual([
+            { key: 'time', value: 'whenever' },
+            { key: 'tags', value: '' },
+            { key: 'image', value: 'javascript:alert(1)' },
+        ]);
+    });
+
+    it('handles prep and cook time independently', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['prep time', '10 min'],
+            ['cook time', 'unknown'],
+        ], {
+            time: { prep_time: 10, cook_time: undefined },
+        }));
+
+        expect(result).toEqual([{ key: 'cook time', value: 'unknown' }]);
+    });
+
+    it('preserves parsed time fields when no time pill can be rendered', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['prep time', '0 min'],
+        ], {
+            time: { prep_time: 0, cook_time: undefined },
+        }));
+
+        expect(result).toEqual([{ key: 'prep time', value: '0 min' }]);
+    });
+
+    it('preserves raw Map ordering and object-special keys', () => {
+        const result = getAdditionalMetadata(recipe([
+            ['2', 'second'],
+            ['1', 'first'],
+            ['__proto__', 'prototype value'],
+        ]));
+
+        expect(result).toEqual([
+            { key: '2', value: 'second' },
+            { key: '1', value: 'first' },
+            { key: '__proto__', value: 'prototype value' },
+        ]);
+    });
+});

--- a/src/utils/metadataEntries.ts
+++ b/src/utils/metadataEntries.ts
@@ -1,19 +1,57 @@
 import type { CooklangRecipe } from '@cooklang/cooklang';
-import { getMetadata } from '../recipeHelpers';
-
-const SHOWN_KEYS = new Set([
-    'title', 'description', 'servings', 'serves', 'yield', 'time', 'prep time',
-    'prep_time', 'cook time', 'cook_time', 'tags', 'tag', 'source', 'author',
-    'difficulty', 'course', 'cuisine', 'diet', 'images', 'image',
-]);
+import { buildMetaPills, type PillKind } from './heroModel';
+import { getRecipeImageUrls } from './recipeImages';
 
 export interface MetadataEntry {
     key: string;
     value: string;
 }
 
+const PILL_KEYS: Partial<Record<string, PillKind>> = {
+    servings: 'servings',
+    tags: 'tag',
+    source: 'source',
+    author: 'author',
+    difficulty: 'difficulty',
+    course: 'course',
+    cuisine: 'cuisine',
+    diet: 'diet',
+};
+
+function hasText(value: unknown): boolean {
+    return value != null && String(value).trim().length > 0;
+}
+
+function hasTimePart(recipe: CooklangRecipe, part: 'prep_time' | 'cook_time'): boolean {
+    if (!recipe.time || typeof recipe.time !== 'object') return false;
+    return recipe.time[part] != null;
+}
+
+/** Whether this exact, case-sensitive raw key is represented elsewhere in the preview. */
+function isHandledMetadataKey(
+    recipe: CooklangRecipe,
+    key: string,
+    pillKinds: ReadonlySet<PillKind>,
+): boolean {
+    if (key === 'title') return hasText(recipe.title);
+    if (key === 'description') return hasText(recipe.description);
+    if (key === 'time') {
+        return pillKinds.has('time') && typeof recipe.time === 'number';
+    }
+    if (key === 'prep time') return pillKinds.has('time') && hasTimePart(recipe, 'prep_time');
+    if (key === 'cook time') return pillKinds.has('time') && hasTimePart(recipe, 'cook_time');
+    if (key === 'image') return getRecipeImageUrls(recipe.images).length > 0;
+
+    const pillKind = PILL_KEYS[key];
+    return pillKind !== undefined && pillKinds.has(pillKind);
+}
+
 export function getAdditionalMetadata(recipe: CooklangRecipe): MetadataEntry[] {
-    return Object.entries(getMetadata(recipe))
-        .filter(([key]) => !SHOWN_KEYS.has(key.toLowerCase().trim()))
-        .map(([key, value]) => ({ key, value }));
+    const pillKinds = new Set(buildMetaPills(recipe, null).map(pill => pill.kind));
+
+    return Array.from(recipe.rawMetadata, ([key, value]) => ({
+        key: String(key),
+        value: String(value),
+    }))
+        .filter(entry => !isHandledMetadataKey(recipe, entry.key, pillKinds));
 }

--- a/src/utils/recipeImages.test.ts
+++ b/src/utils/recipeImages.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getRecipeImageUrls } from './recipeImages';
+
+describe('getRecipeImageUrls', () => {
+    it('normalizes a single image URL', () => {
+        expect(getRecipeImageUrls(' https://example.com/dinner.jpg ')).toEqual([
+            'https://example.com/dinner.jpg',
+        ]);
+    });
+
+    it('preserves valid URLs from image arrays in parser order', () => {
+        expect(getRecipeImageUrls([
+            'https://example.com/first.jpg',
+            null,
+            '',
+            'http://example.com/second.png',
+            42,
+        ])).toEqual([
+            'https://example.com/first.jpg',
+            'http://example.com/second.png',
+        ]);
+    });
+
+    it('rejects malformed and non-web image values', () => {
+        expect(getRecipeImageUrls('dinner.jpg')).toEqual([]);
+        expect(getRecipeImageUrls('javascript:alert(1)')).toEqual([]);
+        expect(getRecipeImageUrls({ url: 'https://example.com/dinner.jpg' })).toEqual([]);
+    });
+});

--- a/src/utils/recipeImages.ts
+++ b/src/utils/recipeImages.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalizes the Cooklang parser's loosely typed canonical image metadata.
+ * The specification permits either one URL or an array of URLs.
+ */
+import { getSafeExternalUrl } from './urlValidators';
+
+export function getRecipeImageUrls(value: unknown): string[] {
+    const candidates = Array.isArray(value) ? value : [value];
+
+    return candidates.flatMap(candidate => {
+        const url = getSafeExternalUrl(candidate);
+        return url ? [url] : [];
+    });
+}

--- a/src/utils/recipeReferences.test.ts
+++ b/src/utils/recipeReferences.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { resolveReferenceCandidatePaths, resolveReferencePath } from './recipeReferences';
 
 describe('resolveReferencePath', () => {
-    it('resolves a "./Sub/Name" reference relative to the recipe folder', () => {
-        expect(resolveReferencePath('Breakfast', ['.', 'Components'], 'Beans'))
-            .toBe('Breakfast/Components/Beans.cook');
+    it('resolves a "./Sub/Name" reference relative to the recipes root', () => {
+        expect(resolveReferencePath('', ['.', 'Components'], 'Beans'))
+            .toBe('Components/Beans.cook');
     });
 
-    it('resolves a same-folder reference', () => {
-        expect(resolveReferencePath('Breakfast', ['.'], 'Salsa'))
-            .toBe('Breakfast/Salsa.cook');
+    it('does not use the containing recipe folder as the root', () => {
+        expect(resolveReferencePath('', ['.'], 'Salsa'))
+            .toBe('Salsa.cook');
     });
 
     it('handles parent navigation with ".."', () => {
@@ -29,8 +29,8 @@ describe('resolveReferencePath', () => {
 
 describe('resolveReferenceCandidatePaths', () => {
     it('returns the .cook target before the same-path .md fallback', () => {
-        expect(resolveReferenceCandidatePaths('Breakfast', ['.', 'Components'], 'Beans'))
-            .toEqual(['Breakfast/Components/Beans.cook', 'Breakfast/Components/Beans.md']);
+        expect(resolveReferenceCandidatePaths('', ['.', 'Components'], 'Beans'))
+            .toEqual(['Components/Beans.cook', 'Components/Beans.md']);
     });
 
     it('keeps parent navigation identical for both candidate extensions', () => {

--- a/src/utils/recipeReferences.ts
+++ b/src/utils/recipeReferences.ts
@@ -3,26 +3,26 @@
  *
  * A reference like `@./Components/Beans` parses to
  * { name: "Beans", components: [".", "Components"] }. The components are a path
- * relative to the referencing recipe's own folder; "." stays, ".." goes up.
- * This resolves that to concrete vault paths, with `.cook` remaining the
- * primary Cooklang target and a `.md` recipe as a plugin-specific fallback.
+ * relative to the root of the recipe collection. In Obsidian, the vault root
+ * is the recipe collection root. This resolves that to concrete vault paths,
+ * with `.cook` remaining the primary Cooklang target and a `.md` recipe as a
+ * plugin-specific fallback.
  */
 
 /**
- * Resolve a reference to a `.cook` vault path, relative to the folder of the
- * recipe that contains the reference.
+ * Resolve a reference to a `.cook` vault path from the recipe collection root.
  *
- * @param recipeFolder - Vault path of the referencing recipe's folder ('' = root)
+ * @param recipesRoot - Vault path of the recipe collection root ('' = vault root)
  * @param components - Reference path components (e.g. [".", "Components"])
  * @param name - Referenced recipe name (e.g. "Beans")
  * @returns Normalised vault path like "Breakfast/Components/Beans.cook"
  */
 export function resolveReferencePath(
-    recipeFolder: string,
+    recipesRoot: string,
     components: string[],
     name: string,
 ): string {
-    return resolveReferenceBasePath(recipeFolder, components, name) + '.cook';
+    return resolveReferenceBasePath(recipesRoot, components, name) + '.cook';
 }
 
 /**
@@ -31,20 +31,20 @@ export function resolveReferencePath(
  * `.md` path only when it is known to be a Cooklang recipe in Obsidian.
  */
 export function resolveReferenceCandidatePaths(
-    recipeFolder: string,
+    recipesRoot: string,
     components: string[],
     name: string,
 ): [cookPath: string, markdownPath: string] {
-    const basePath = resolveReferenceBasePath(recipeFolder, components, name);
+    const basePath = resolveReferenceBasePath(recipesRoot, components, name);
     return [basePath + '.cook', basePath + '.md'];
 }
 
 function resolveReferenceBasePath(
-    recipeFolder: string,
+    recipesRoot: string,
     components: string[],
     name: string,
 ): string {
-    const segments = recipeFolder ? recipeFolder.split('/').filter(Boolean) : [];
+    const segments = recipesRoot ? recipesRoot.split('/').filter(Boolean) : [];
 
     for (const component of components) {
         if (component === '' || component === '.') continue;

--- a/src/utils/scaling.test.ts
+++ b/src/utils/scaling.test.ts
@@ -1,18 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { parseServingsValue, computeScale, clampServings, deriveServingsState } from './scaling';
+import {
+    parseServingsValue,
+    computeReferenceScale,
+    computeScale,
+    clampServings,
+    deriveServingsState,
+} from './scaling';
 
 describe('parseServingsValue', () => {
     it('accepts positive numbers', () => {
         expect(parseServingsValue(4)).toBe(4);
     });
-    it('extracts leading number from strings like "4 servings"', () => {
+    it('extracts a leading number from strings like "4 servings"', () => {
         expect(parseServingsValue('4 servings')).toBe(4);
-        expect(parseServingsValue('serves 6')).toBe(6);
+        expect(parseServingsValue('  2.5 servings')).toBe(2.5);
     });
-    it('returns null for non-positive or non-numeric', () => {
+    it('defaults omitted servings to one', () => {
+        expect(parseServingsValue(undefined)).toBe(1);
+    });
+    it('rejects numbers that are not at the start', () => {
+        expect(parseServingsValue('serves 6')).toBeNull();
+    });
+    it('returns null for non-positive or non-numeric metadata', () => {
         expect(parseServingsValue(0)).toBeNull();
         expect(parseServingsValue('a lot')).toBeNull();
-        expect(parseServingsValue(undefined)).toBeNull();
     });
 });
 
@@ -26,9 +37,27 @@ describe('computeScale', () => {
     });
 });
 
+describe('computeReferenceScale', () => {
+    it('uses a unitless quantity as a direct multiplier', () => {
+        expect(computeReferenceScale({ quantity: 2, unit: null }, 4, '500%ml')).toBe(2);
+    });
+
+    it('targets the referenced recipe servings', () => {
+        expect(computeReferenceScale({ quantity: 4, unit: 'servings' }, 2, null)).toBe(2);
+    });
+
+    it('targets a matching yield unit', () => {
+        expect(computeReferenceScale({ quantity: 150, unit: 'ml' }, 2, '500%ml')).toBe(0.3);
+    });
+
+    it('does not apply yield scaling when units differ', () => {
+        expect(computeReferenceScale({ quantity: 150, unit: 'g' }, 2, '500%ml')).toBe(1);
+    });
+});
+
 describe('clampServings', () => {
-    it('rounds and clamps to [1, 1000]', () => {
-        expect(clampServings(3.6)).toBe(4);
+    it('preserves fractions and clamps to [1, 1000]', () => {
+        expect(clampServings(3.6)).toBe(3.6);
         expect(clampServings(0)).toBe(1);
         expect(clampServings(99999)).toBe(1000);
     });
@@ -44,8 +73,8 @@ describe('deriveServingsState', () => {
         expect(deriveServingsState(2, 3)).toEqual({ baseServings: 2, displayServings: 6 });
     });
 
-    it('rounds and clamps the display to a positive integer', () => {
-        expect(deriveServingsState(3, 0.5)).toEqual({ baseServings: 3, displayServings: 2 });
+    it('preserves fractional servings and clamps the display to a positive value', () => {
+        expect(deriveServingsState(3, 0.5)).toEqual({ baseServings: 3, displayServings: 1.5 });
         expect(deriveServingsState(1, 0.1)).toEqual({ baseServings: 1, displayServings: 1 });
     });
 

--- a/src/utils/scaling.ts
+++ b/src/utils/scaling.ts
@@ -6,15 +6,21 @@
 // locally (it is `number | string`).
 type Servings = number | string;
 
-/** Numeric base servings from recipe metadata, or null if not derivable. */
+export interface RecipeReferenceScaleRequest {
+    quantity: number;
+    unit: string | null;
+}
+
+/** Numeric base servings from recipe metadata, defaulting to one when omitted. */
 export function parseServingsValue(servings: Servings | undefined): number | null {
+    if (servings === undefined) return 1;
     if (typeof servings === 'number') {
         return servings > 0 ? servings : null;
     }
     if (typeof servings === 'string') {
-        const match = servings.match(/\d+(\.\d+)?/);
+        const match = servings.match(/^\s*(\d+(?:\.\d+)?)/);
         if (match) {
-            const n = parseFloat(match[0]);
+            const n = parseFloat(match[1]);
             if (n > 0) return n;
         }
     }
@@ -27,9 +33,48 @@ export function computeScale(targetServings: number, baseServings: number): numb
     return targetServings / baseServings;
 }
 
-/** Round to an integer servings count within sane bounds. */
+interface ParsedYield {
+    quantity: number;
+    unit: string;
+}
+
+function parseYieldValue(value: unknown): ParsedYield | null {
+    if (typeof value !== 'string') return null;
+    const match = value.match(/^\s*(\d+(?:\.\d+)?)\s*(?:%|\s)\s*(\S.*?)\s*$/);
+    if (!match) return null;
+    const quantity = Number(match[1]);
+    return quantity > 0
+        ? { quantity, unit: match[2].trim() }
+        : null;
+}
+
+function normalizedUnit(unit: string): string {
+    return unit.trim().toLowerCase().replace(/s$/, '');
+}
+
+/** Resolve a reference quantity to the scale factor for the target recipe. */
+export function computeReferenceScale(
+    request: RecipeReferenceScaleRequest | null,
+    servings: Servings | undefined,
+    yieldValue: unknown,
+): number {
+    if (!request || !Number.isFinite(request.quantity) || request.quantity <= 0) return 1;
+    if (!request.unit?.trim()) return request.quantity;
+
+    if (normalizedUnit(request.unit) === 'serving') {
+        const baseServings = parseServingsValue(servings);
+        return baseServings === null ? 1 : computeScale(request.quantity, baseServings);
+    }
+
+    const parsedYield = parseYieldValue(yieldValue);
+    return parsedYield && normalizedUnit(parsedYield.unit) === normalizedUnit(request.unit)
+        ? request.quantity / parsedYield.quantity
+        : 1;
+}
+
+/** Clamp a servings count within sane bounds without discarding fractions. */
 export function clampServings(value: number, min = 1, max = 1000): number {
-    return Math.max(min, Math.min(max, Math.round(value)));
+    return Math.max(min, Math.min(max, value));
 }
 
 export interface ServingsState {

--- a/src/utils/urlValidators.test.ts
+++ b/src/utils/urlValidators.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getSafeExternalUrl } from './urlValidators';
+
+describe('getSafeExternalUrl', () => {
+    it('normalizes HTTP(S) URLs', () => {
+        expect(getSafeExternalUrl(' https://example.com/recipe?q=one '))
+            .toBe('https://example.com/recipe?q=one');
+        expect(getSafeExternalUrl('http://localhost:8080')).toBe('http://localhost:8080');
+        expect(getSafeExternalUrl('HTTPS://EXAMPLE.COM')).toBe('HTTPS://EXAMPLE.COM');
+    });
+
+    it.each([
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'file:///tmp/recipe.cook',
+        'ftp://example.com/recipe',
+        'mailto:cook@example.com',
+        'obsidian://open?vault=Recipes',
+        'blob:https://example.com/id',
+        '/relative/path',
+        'not a url',
+        '',
+    ])('rejects non-web or malformed URL %s', value => {
+        expect(getSafeExternalUrl(value)).toBeNull();
+    });
+
+    it('rejects non-string values', () => {
+        expect(getSafeExternalUrl(null)).toBeNull();
+        expect(getSafeExternalUrl({ url: 'https://example.com' })).toBeNull();
+    });
+});

--- a/src/utils/urlValidators.ts
+++ b/src/utils/urlValidators.ts
@@ -2,21 +2,19 @@
  * URL validation utilities
  */
 
-/**
- * Validates if a string is a valid URL
- * @param str - The string to validate
- * @returns true if the string is a valid URL, false otherwise
- *
- * @example
- * isValidUrl('https://example.com') // true
- * isValidUrl('not a url') // false
- * isValidUrl('ftp://files.example.com') // true
- */
-export function isValidUrl(str: string): boolean {
+/** Return a normalized HTTP(S) URL that is safe to expose as an external link. */
+export function getSafeExternalUrl(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+
+    const candidate = value.trim();
+    if (!candidate) return null;
+
     try {
-        new URL(str);
-        return true;
+        const url = new URL(candidate);
+        return url.protocol === 'http:' || url.protocol === 'https:'
+            ? candidate
+            : null;
     } catch {
-        return false;
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

- preserve forced step line breaks and render headings for single named sections
- resolve recipe references from the vault root and apply unitless, servings, or yield-based scaling when opening targets
- support safe remote hero images, preserve unhandled metadata aliases and parser ordering, and restrict actionable metadata URLs to HTTP(S)
- document the updated reference, image, and one-based step-image behavior

## Validation

- npm test — 142 tests passed
- npm run build — production bundle generated successfully
- git diff --check — clean

## Manual verification

- Obsidian desktop/mobile verification was not available in this environment.